### PR TITLE
fix(coreml-export): guard FP16 cast sites against Inf/NaN production

### DIFF
--- a/src/terncore/coreml_export.py
+++ b/src/terncore/coreml_export.py
@@ -174,6 +174,73 @@ ARCH_PRESETS = {
 # Weight loading from .tern-model
 # ---------------------------------------------------------------------------
 
+FP16_MAX = 65504.0
+
+
+def _validate_ternary2_alpha(alpha: float, name: str) -> None:
+    """Guard a ternary2 alpha against silent FP16 overflow.
+
+    Non-finite alpha indicates a quantiser bug upstream; out-of-range
+    alpha indicates a degenerate quantisation case. Either would cast
+    to Inf in FP16 and break downstream palettisation. Both raise
+    rather than silently clamp — clamping would mask the upstream bug.
+    """
+    if not np.isfinite(alpha):
+        raise ValueError(
+            f"Non-finite alpha {alpha} for ternary2 layer "
+            f"{name}. This indicates a quantiser bug upstream "
+            f"(likely in convert.py ternary2 path); the cast "
+            f"to FP16 would silently produce Inf/NaN and break "
+            f"downstream palettisation. Refusing to emit."
+        )
+    if abs(alpha) > FP16_MAX:
+        raise ValueError(
+            f"Alpha {alpha} for ternary2 layer {name} exceeds "
+            f"FP16 range (±{int(FP16_MAX)}). This indicates a "
+            f"degenerate quantisation case (e.g., sparse or "
+            f"all-zero block); the cast to FP16 would silently "
+            f"produce Inf. Refusing to emit."
+        )
+
+
+def _cast_fp16_retain_with_guards(
+    weight_fp32: np.ndarray, name: str
+) -> np.ndarray:
+    """Cast a protected FP32 weight to FP16 with finite/range guards.
+
+    Three-way handling distinguishes input-bug (raise) from
+    representation-bug (clamp):
+      - Source NaN/Inf: raise (source-model corruption upstream).
+      - Finite but |value| > FP16_MAX: clamp to ±FP16_MAX with
+        operator-visible WARNING. Preserves the run on legitimate
+        outliers while surfacing them for investigation.
+      - Finite within range: cast as-is.
+    """
+    if not np.all(np.isfinite(weight_fp32)):
+        n_nan = int(np.isnan(weight_fp32).sum())
+        n_inf = int(np.isinf(weight_fp32).sum())
+        raise ValueError(
+            f"Non-finite values in fp16_retain layer {name}: "
+            f"{n_nan} NaN, {n_inf} Inf in source FP32 weight. "
+            f"This indicates a source-model corruption or an "
+            f"upstream bug; refusing to emit silently."
+        )
+    abs_max = float(np.abs(weight_fp32).max())
+    if abs_max > FP16_MAX:
+        n_clamped_high = int((weight_fp32 >  FP16_MAX).sum())
+        n_clamped_low  = int((weight_fp32 < -FP16_MAX).sum())
+        print(
+            f"WARNING: fp16_retain layer {name} has values "
+            f"outside FP16 range (abs_max={abs_max:.3e}); "
+            f"clamping {n_clamped_high} values to +{int(FP16_MAX)} "
+            f"and {n_clamped_low} values to -{int(FP16_MAX)}. "
+            f"Source weight may have an outlier worth investigating.",
+            flush=True,
+        )
+        weight_fp32 = np.clip(weight_fp32, -FP16_MAX, FP16_MAX)
+    return weight_fp32.astype(np.float16)
+
+
 def _load_weight_for_coreml(reader: TernModelReader, name: str):
     """Load a weight from the .tern-model and prepare for CoreML injection.
 
@@ -229,13 +296,16 @@ def _load_weight_for_coreml(reader: TernModelReader, name: str):
             ternary = np.pad(ternary, ((0, 0), (0, padded_in - in_f)))
         n_blocks = padded_in // block_size
         int4_data = ternary.astype(np.int8).astype(types.np_int4_dtype)
+        _validate_ternary2_alpha(alpha, name)
         scales = np.full((shape[0], n_blocks), alpha, dtype=np.float16)
 
         return "int4", int4_data, scales, padded_in
 
     elif dtype == "float16":
         tensors = reader.reconstruct_layer(name)
-        return "fp16", tensors["weight"].numpy().astype(np.float16)
+        weight_fp32 = tensors["weight"].numpy()
+        weight_fp16 = _cast_fp16_retain_with_guards(weight_fp32, name)
+        return "fp16", weight_fp16
 
     else:
         raise ValueError(f"Unknown dtype {dtype} for {name}")

--- a/tests/test_coreml_export.py
+++ b/tests/test_coreml_export.py
@@ -1,0 +1,100 @@
+"""
+Tests for the FP16 cast guards in terncore.coreml_export.
+
+Covers _validate_ternary2_alpha and _cast_fp16_retain_with_guards —
+the two helpers that gate the FP32→FP16 cast sites against silent
+Inf/NaN production. Closes tern-core #1.
+
+All tests use synthetic numpy/scalar inputs — no .tern-model files,
+no HuggingFace downloads.
+
+Patents 38, 41: Configurable precision + compiler scheduling — the
+guards preserve the FP16-retain compression contract by rejecting
+inputs that would silently break it.
+
+Run with: pytest tests/test_coreml_export.py -v
+"""
+
+import math
+
+import numpy as np
+import pytest
+
+from terncore.coreml_export import (
+    FP16_MAX,
+    _cast_fp16_retain_with_guards,
+    _validate_ternary2_alpha,
+)
+
+
+# ═══════════════════════════════════════════════════════════════
+# _validate_ternary2_alpha
+# ═══════════════════════════════════════════════════════════════
+
+
+def test_alpha_passes_clean():
+    """A finite alpha within FP16 range returns None and does not raise."""
+    assert _validate_ternary2_alpha(0.05, "model.layers.0.mlp.gate_proj") is None
+
+
+def test_alpha_raises_on_nonfinite():
+    """Non-finite alpha (Inf or NaN) is a quantiser bug — refuse to emit."""
+    with pytest.raises(ValueError, match="Non-finite alpha"):
+        _validate_ternary2_alpha(float("inf"), "layer.x")
+    with pytest.raises(ValueError, match="Non-finite alpha"):
+        _validate_ternary2_alpha(float("nan"), "layer.y")
+
+
+def test_alpha_raises_on_overflow():
+    """Finite alpha above FP16 ceiling is a degenerate quantisation case."""
+    overflow = FP16_MAX + 1.0
+    with pytest.raises(ValueError, match="exceeds FP16 range"):
+        _validate_ternary2_alpha(overflow, "layer.overflow")
+    with pytest.raises(ValueError, match="exceeds FP16 range"):
+        _validate_ternary2_alpha(-overflow, "layer.overflow_neg")
+
+
+# ═══════════════════════════════════════════════════════════════
+# _cast_fp16_retain_with_guards
+# ═══════════════════════════════════════════════════════════════
+
+
+def test_fp16_retain_passes_clean():
+    """A finite FP32 array within range casts to FP16 unchanged."""
+    src = np.array([-1.5, 0.0, 1.5, 12.0], dtype=np.float32)
+    out = _cast_fp16_retain_with_guards(src, "layer.clean")
+    assert out.dtype == np.float16
+    assert out.shape == src.shape
+    assert np.all(np.isfinite(out))
+    assert np.allclose(out.astype(np.float32), src, atol=1e-3)
+
+
+def test_fp16_retain_raises_on_nan():
+    """A NaN in the source is source-model corruption — refuse to emit."""
+    src = np.array([1.0, float("nan"), 2.0], dtype=np.float32)
+    with pytest.raises(ValueError, match="Non-finite values"):
+        _cast_fp16_retain_with_guards(src, "layer.nan")
+
+
+def test_fp16_retain_raises_on_inf():
+    """An Inf in the source is source-model corruption — refuse to emit."""
+    src = np.array([1.0, float("inf"), 2.0], dtype=np.float32)
+    with pytest.raises(ValueError, match="Non-finite values"):
+        _cast_fp16_retain_with_guards(src, "layer.inf")
+
+
+def test_fp16_retain_clamps_high(capsys):
+    """Finite-but-out-of-range values clamp to ±FP16_MAX with a stdout WARNING."""
+    src = np.array([1.0, 1.0e6, -1.0e6, 5.0], dtype=np.float32)
+    out = _cast_fp16_retain_with_guards(src, "layer.clamp")
+    assert out.dtype == np.float16
+    assert np.all(np.isfinite(out)), "clamped output must be finite"
+    out_f32 = out.astype(np.float32)
+    assert out_f32[1] == pytest.approx(FP16_MAX, abs=1.0)
+    assert out_f32[2] == pytest.approx(-FP16_MAX, abs=1.0)
+    assert math.isclose(out_f32[0], 1.0, abs_tol=1e-3)
+    assert math.isclose(out_f32[3], 5.0, abs_tol=1e-3)
+    captured = capsys.readouterr()
+    assert "WARNING:" in captured.out
+    assert "layer.clamp" in captured.out
+    assert "clamping" in captured.out


### PR DESCRIPTION
Closes #1.

## Summary

Adds finite-and-range checks at the two FP32→FP16 cast sites in `_load_weight_for_coreml`, extracted as two named helpers (`_validate_ternary2_alpha`, `_cast_fp16_retain_with_guards`) with `FP16_MAX = 65504.0` as a named constant.

## Approach

Three-way handling distinguishes input-bug (raise) from representation-bug (clamp):

- **Non-finite alpha or |alpha| > FP16_MAX** → raise. Clamping would mask a quantiser bug upstream.
- **Non-finite source FP32 weight** (NaN/Inf) → raise. Source-model corruption shouldn't propagate silently.
- **Finite but |value| > FP16_MAX in fp16_retain** → clamp to ±FP16_MAX with operator-visible WARNING. Preserves the run on legitimate outliers while surfacing them.

## Validation

DSR1-7B export+palettise pipeline:
- Clean pre-fix (baseline confirmed during diagnosis)
- Clean post-fix (export 49.8s, palettise saved, zero guard activations on legitimate inputs)

Full pytest suite post-fix: **310 passed, 19 skipped (no regressions)**.

Mistral-7B re-export pending WD Passport archive mount; will validate end-to-end then.

## Tests

`tests/test_coreml_export.py`: 7 cases covering clean pass-through, all pathology raises, and the clamp-with-warning path.