### PR TITLE
fix(ci): close TestAccelInfo failures (workflow ordering + version sync)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,12 +21,12 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e ".[dev,transformers]"
-      - name: Run tests
-        run: pytest tests/ -v --tb=short
       - name: Build C kernels
         run: |
           cd src/terncore/csrc
           make clean && make
+      - name: Run tests
+        run: pytest tests/ -v --tb=short
       - name: Run C tests
         run: |
           cd src/terncore/csrc

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ src/terncore/csrc/test_matmul
 src/terncore/csrc/test_packed
 src/terncore/csrc/test_simd
 src/terncore/csrc/test_sparse_skip
+
+# Build-time generated headers
+src/terncore/csrc/terncore_version.h

--- a/src/terncore/csrc/Makefile
+++ b/src/terncore/csrc/Makefile
@@ -64,11 +64,41 @@ endif
 ALL_SRCS = $(COMMON_SRCS) $(SIMD_SRCS)
 OBJS     = $(ALL_SRCS:.c=.o)
 
+# ── Version header generation from pyproject.toml ───────────────────
+#
+# Single source of truth: bumps in pyproject.toml flow to the C
+# kernel automatically at build time. Uses tomllib (Python 3.11+) or
+# falls back to tomli (Python 3.10) per pyproject.toml's
+# requires-python = ">=3.10".
+
+PYPROJECT      = ../../../pyproject.toml
+VERSION_HEADER = terncore_version.h
+
+.DEFAULT_GOAL := all
+
+define VERSION_HEADER_SCRIPT
+try:
+    import tomllib
+except ImportError:
+    import tomli as tomllib
+with open('$(PYPROJECT)', 'rb') as f:
+    v = tomllib.load(f)['project']['version']
+print('#ifndef TERNCORE_VERSION_H')
+print('#define TERNCORE_VERSION_H')
+print(f'#define TERNCORE_VERSION_STRING "{v}"')
+print('#endif')
+endef
+export VERSION_HEADER_SCRIPT
+
+$(VERSION_HEADER): $(PYPROJECT)
+	@echo "Generating $@ from $<"
+	@python3 -c "$$VERSION_HEADER_SCRIPT" > $@
+
 # ── Targets ─────────────────────────────────────────────────────────
 
 .PHONY: all clean test
 
-all: $(LIB)
+all: $(VERSION_HEADER) $(LIB)
 
 $(LIB): $(OBJS)
 	$(CC) $(LDFLAGS) -o $@ $^
@@ -114,4 +144,4 @@ test: test_matmul test_packed test_sparse_skip test_simd
 # ── Cleanup ─────────────────────────────────────────────────────────
 
 clean:
-	rm -f $(OBJS) $(LIB) test_matmul test_packed test_sparse_skip test_simd
+	rm -f $(OBJS) $(LIB) $(VERSION_HEADER) test_matmul test_packed test_sparse_skip test_simd

--- a/src/terncore/csrc/Makefile
+++ b/src/terncore/csrc/Makefile
@@ -111,7 +111,7 @@ ternary_avx2.o: ternary_avx2.c ternary_simd.h ternary_packed.h ternary_matmul.h
 ternary_neon.o: ternary_neon.c ternary_simd.h ternary_packed.h ternary_matmul.h
 	$(CC) $(CFLAGS) -c -o $@ $<
 
-bindings.o: bindings.c sparse_skip.h ternary_simd.h ternary_packed.h ternary_matmul.h
+bindings.o: bindings.c sparse_skip.h ternary_simd.h ternary_packed.h ternary_matmul.h $(VERSION_HEADER)
 	$(CC) $(CFLAGS) $(AVX2_FLAGS) -c -o $@ $<
 
 %.o: %.c

--- a/src/terncore/csrc/Makefile
+++ b/src/terncore/csrc/Makefile
@@ -127,8 +127,8 @@ test_matmul: test_matmul.c ternary_matmul.c
 test_packed: test_packed.c ternary_packed.c ternary_matmul.c
 	$(CC) $(CFLAGS) $(OMP_CFLAGS) $(OMP_LDFLAGS) -o $@ $^
 
-test_sparse_skip: test_sparse_skip.c $(ALL_C)
-	$(CC) $(CFLAGS) $(OMP_CFLAGS) $(AVX2_FLAGS) $(OMP_LDFLAGS) -o $@ $^
+test_sparse_skip: test_sparse_skip.c $(ALL_C) $(VERSION_HEADER)
+	$(CC) $(CFLAGS) $(OMP_CFLAGS) $(AVX2_FLAGS) $(OMP_LDFLAGS) -o $@ test_sparse_skip.c $(ALL_C)
 
 test_simd: test_simd.c $(ALL_C)
 	$(CC) $(CFLAGS) $(OMP_CFLAGS) $(AVX2_FLAGS) $(OMP_LDFLAGS) -o $@ $^

--- a/src/terncore/csrc/bindings.c
+++ b/src/terncore/csrc/bindings.c
@@ -34,6 +34,7 @@
 
 #include "sparse_skip.h"      /* includes ternary_packed.h → ternary_matmul.h */
 #include "ternary_simd.h"     /* TERN_SIMD_*, AVX2/NEON kernel declarations   */
+#include "terncore_version.h" /* TERNCORE_VERSION_STRING (build-time, from pyproject.toml) */
 
 /* ── Cached SIMD capabilities ────────────────────────────────────── */
 
@@ -192,10 +193,11 @@ uint32_t get_simd_support(void)
 /* ══════════════════════════════════════════════════════════════════════
  * terncore_version — Library version string
  *
- * Returns a pointer to a static string.  Matches the version in
- * pyproject.toml.
+ * Returns a pointer to a static string.  TERNCORE_VERSION_STRING is
+ * generated at build time from pyproject.toml's [project] version
+ * field — see terncore_version.h and the Makefile rule.
  * ═════════════════════════════════════════════════════════════════════*/
 const char *terncore_version(void)
 {
-    return "0.1.0";
+    return TERNCORE_VERSION_STRING;
 }

--- a/src/terncore/csrc/test_sparse_skip.c
+++ b/src/terncore/csrc/test_sparse_skip.c
@@ -16,6 +16,7 @@
 #include "ternary_matmul.h"
 #include "ternary_packed.h"
 #include "sparse_skip.h"
+#include "terncore_version.h"  /* TERNCORE_VERSION_STRING (build-time, from pyproject.toml) */
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -454,7 +455,8 @@ static void test_version(void)
 {
     const char *ver = terncore_version();
     ASSERT(ver != NULL, "version not NULL");
-    ASSERT(strcmp(ver, "0.1.0") == 0, "version is 0.1.0");
+    ASSERT(strcmp(ver, TERNCORE_VERSION_STRING) == 0,
+           "terncore_version() returns build-time TERNCORE_VERSION_STRING");
 }
 
 /* ── Main ────────────────────────────────────────────────────────── */


### PR DESCRIPTION
Closes #4.

## Summary

Two distinct root causes for the `TestAccelInfo` failures that have made CI red on every push since 2026-03-27:

1. **`test_library_path_exists`** failed because the GitHub Actions workflow ran `pytest` before `make`, so the C library didn't exist when the test collected.

2. **`test_version_matches_package`** failed because the C kernel's `terncore_version()` returned a hardcoded `"0.1.0"` literal that had drifted from `pyproject.toml`'s `0.4.0` across v0.2.0 → v0.4.0 bumps with no sync mechanism.

## Approach

Three commits, each independently revertable:

| Commit | Change |
|---|---|
| `build(csrc)` | Adds Makefile target generating `terncore_version.h` from `pyproject.toml` at build time. Header is gitignored. Uses tomllib (3.11+) or tomli fallback (3.10). |
| `fix(csrc)` | Replaces hardcoded `"0.1.0"` in `bindings.c` with `TERNCORE_VERSION_STRING` from the generated header. |
| `ci(workflow)` | Swaps step order: build C kernels before running pytest. |

The first two commits close the version-sync regression class — future version bumps in `pyproject.toml` automatically update the C kernel's reported version with no manual sync needed.

## Validation

- `pytest tests/test_stage1b.py`: **30 passed** including both previously-failing TestAccelInfo tests
- `pytest tests/`: **326 passed, 3 skipped** (no regressions; up from 310/19 baseline because more `is_accelerated()`-gated tests now run with the freshly-built accel library)
- `make clean && make`: header generates from pyproject.toml, dylib builds, runtime check confirms `terncore_version()` returns `"0.4.0"` matching `pyproject.toml`

## Out of scope

`get_acceleration_info()['library_path']` only tracks the ctypes backend; the torch cpp_extension backend leaves it `None`. This isn't a bug given the current test contract (build before pytest means ctypes backend is loaded), but it's a latent semantic gap if we ever ship CI without the make step. Tracked for a future session if the dual-backend reporting becomes load-bearing.