### PR TITLE
Phase 2.5 Stage 2: Metal-aware forward + production e2e

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,9 @@ where = ["src"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = "-v --tb=short"
+markers = [
+    "slow: marks tests that take >5s (deselect with -m 'not slow')",
+]
 filterwarnings = [
     "ignore::DeprecationWarning",
     "ignore::FutureWarning",

--- a/src/terncore/packed_linear.py
+++ b/src/terncore/packed_linear.py
@@ -96,6 +96,14 @@ class PackedTernaryLinear(nn.Module):
         else:
             self.register_parameter("bias", None)
 
+        # Metal kernel state — lazy-allocated on first MPS-device forward.
+        # Not registered buffers (those are autograd-tracked tensors); these
+        # are GPUBuffer handles into the Metal engine's command-allocator pool.
+        self._metal_buffers_initialised: bool = False
+        self._metal_engine = None
+        self._metal_codes_buf = None
+        self._metal_scales_buf = None
+
     @classmethod
     def from_float(
         cls,
@@ -233,12 +241,85 @@ class PackedTernaryLinear(nn.Module):
 
         return layer
 
+    def _initialise_metal_buffers(self) -> None:
+        """One-shot lazy init of GPU-resident weight buffers.
+
+        Called from the first MPS forward. If Metal is unavailable, sets
+        the initialised flag True with engine=None so the caller falls
+        back without retrying.
+        """
+        import numpy as np
+        from terncore.metal_runtime import get_engine
+        from terncore.ternary_metal import repack_uint8_to_uint32_codes
+
+        self._metal_buffers_initialised = True  # one-shot, sticky on failure
+        self._metal_engine = get_engine()
+        if self._metal_engine is None:
+            return  # Metal unavailable — caller falls through to CPU path
+
+        # Repack uint8 (CPU layout) → uint32 (Metal layout). packed_weights
+        # may be MPS-resident if the layer was .to("mps")'d; .cpu() is a
+        # no-op when already on CPU.
+        codes = repack_uint8_to_uint32_codes(
+            self.packed_weights.cpu(), self.in_features, self.out_features,
+        )
+        codes_u32_np = codes.numpy().astype(np.uint32)
+        scales_np = np.full(self.out_features, self.alpha.item(), dtype=np.float32)
+
+        self._metal_codes_buf = self._metal_engine.create_buffer(codes_u32_np)
+        self._metal_scales_buf = self._metal_engine.create_buffer(scales_np)
+
+    def _forward_metal(self, x: torch.Tensor) -> torch.Tensor:
+        """Metal-dispatch forward.
+
+        Inputs/outputs round-trip CPU per call (transient input_buf and
+        output_buf); weights stay GPU-resident across forwards via
+        _metal_codes_buf and _metal_scales_buf.
+        """
+        import numpy as np
+
+        x_shape = x.shape
+        x_2d = x.reshape(-1, self.in_features)
+        batch = x_2d.shape[0]
+
+        x_np = np.ascontiguousarray(
+            x_2d.detach().cpu().numpy(), dtype=np.float16
+        )
+        input_buf = self._metal_engine.create_buffer(x_np)
+        output_buf = self._metal_engine.create_buffer(
+            size=batch * self.out_features * 2  # 2 bytes per float16
+        )
+
+        self._metal_engine.matvec_gpu(
+            self._metal_codes_buf, self._metal_scales_buf,
+            input_buf, output_buf,
+            M=self.out_features, K=self.in_features, B=batch, fast=True,
+        )
+
+        output_np = output_buf.read(
+            dtype=np.float16, shape=(batch, self.out_features)
+        )
+        output = torch.from_numpy(output_np.astype(np.float32)).to(x.device)
+        output = output.reshape(*x_shape[:-1], self.out_features)
+
+        if self.bias is not None:
+            output = output + self.bias  # bias on caller device
+        return output
+
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """
-        Forward pass using packed weights with cached bitmap zero-skip.
+        Forward pass.
 
-        Uses the C kernel fast path with pre-built sparsity bitmap when
-        available. Falls back to unpack → float → F.linear.
+        Branches on input device:
+        - MPS-resident inputs dispatch through the Metal kernel via lazy-
+          allocated GPU-resident weight buffers (one-shot init on first
+          MPS forward).
+        - CPU inputs go through the existing C kernel fast path with
+          cached sparsity bitmap zero-skip.
+
+        If Metal is unavailable on an MPS input, falls through to the CPU
+        path which itself falls through to the F.linear reference via the
+        TypeError catch in packed_ternary_matmul_fast.
 
         Patent 7: Cached bitmap eliminates per-call bitmap rebuild.
         Patent 9: Zero-skip via bitmap-driven sparse kernel.
@@ -249,6 +330,13 @@ class PackedTernaryLinear(nn.Module):
         Returns:
             Output tensor (..., out_features).
         """
+        if x.device.type == "mps":
+            if not self._metal_buffers_initialised:
+                self._initialise_metal_buffers()
+            if self._metal_engine is not None:
+                return self._forward_metal(x)
+            # else: fall through to CPU path
+
         output = packed_ternary_matmul_fast(
             x,
             self.packed_weights,

--- a/src/terncore/packed_ops.py
+++ b/src/terncore/packed_ops.py
@@ -143,7 +143,7 @@ def packed_ternary_matmul_fast(
                     *x_shape[:-1], out_features
                 )
                 return result
-    except (ImportError, AttributeError):
+    except (ImportError, AttributeError, TypeError):
         pass
 
     # Fallback: unpack → float → F.linear

--- a/tests/test_packed_linear.py
+++ b/tests/test_packed_linear.py
@@ -380,3 +380,46 @@ class TestTernModelReaderPacked:
             assert output.shape == (2, 8)
         finally:
             Path(path).unlink(missing_ok=True)
+
+
+# ═══════════════════════════════════════════════════════════════
+# MPS device fallback discipline
+# ═══════════════════════════════════════════════════════════════
+
+
+class TestMPSFallback:
+    """PackedTernaryLinear.forward must fall back gracefully when invoked
+    on MPS-resident inputs. The C kernel fast path can't accept MPS
+    tensors via .numpy() (raises TypeError); the except clause in
+    packed_ternary_matmul_fast catches it and dispatches through the
+    dequantise→F.linear reference path which is MPS-compatible."""
+
+    @pytest.mark.skipif(
+        not torch.backends.mps.is_available(),
+        reason="MPS unavailable on this host",
+    )
+    def test_mps_input_falls_back_without_crash(self):
+        """MPS-resident forward must not crash and must produce
+        per-element-equivalent output to the CPU forward."""
+        torch.manual_seed(500)
+        linear = nn.Linear(64, 32, bias=True)
+        packed = PackedTernaryLinear.from_float(linear, threshold=0.7)
+        packed.eval()
+
+        x_cpu = torch.randn(4, 64)
+        with torch.no_grad():
+            cpu_out = packed(x_cpu)
+
+        packed_mps = packed.to("mps")
+        x_mps = x_cpu.to("mps")
+        with torch.no_grad():
+            mps_out = packed_mps(x_mps)
+
+        assert mps_out.device.type == "mps", (
+            f"expected MPS-resident output, got {mps_out.device}"
+        )
+        mps_out_cpu = mps_out.cpu()
+        max_diff = (cpu_out - mps_out_cpu).abs().max().item()
+        assert torch.allclose(cpu_out, mps_out_cpu, atol=1e-4), (
+            f"MPS vs CPU divergence: {max_diff} (atol=1e-4)"
+        )

--- a/tests/test_packed_linear.py
+++ b/tests/test_packed_linear.py
@@ -388,19 +388,34 @@ class TestTernModelReaderPacked:
 
 
 class TestMPSFallback:
-    """PackedTernaryLinear.forward must fall back gracefully when invoked
-    on MPS-resident inputs. The C kernel fast path can't accept MPS
-    tensors via .numpy() (raises TypeError); the except clause in
-    packed_ternary_matmul_fast catches it and dispatches through the
-    dequantise→F.linear reference path which is MPS-compatible."""
+    """Verify the TypeError fallback path through F.linear for MPS-resident
+    inputs. After Commit 4 added the Metal-aware forward, MPS inputs route
+    through the Metal kernel by default; this test forces Metal unavailable
+    via monkeypatch to specifically exercise the C-kernel→TypeError-catch→
+    F.linear reference fallback path that Commit 3 fixed."""
 
     @pytest.mark.skipif(
         not torch.backends.mps.is_available(),
         reason="MPS unavailable on this host",
     )
-    def test_mps_input_falls_back_without_crash(self):
-        """MPS-resident forward must not crash and must produce
-        per-element-equivalent output to the CPU forward."""
+    def test_mps_input_falls_back_without_crash(self, monkeypatch):
+        """Forces Metal unavailable via monkeypatch to verify the TypeError
+        fallback path through F.linear works correctly. Independent
+        regression guard against the CPU C kernel path crashing on
+        MPS-resident packed_weights.numpy() calls (Commit 3 fix).
+
+        With Metal forced unavailable, the test exercises the F.linear
+        reference path (float32 precision); 1e-4 tolerance is correct
+        for that path. The implicit secondary assertion: if the
+        monkeypatch silently failed and Metal ran, divergence would be
+        ~5e-4 (float16 precision) and the assert would fail loudly."""
+        # Force Metal unavailable so PackedTernaryLinear.forward falls
+        # through to the CPU C kernel path → TypeError catch →
+        # F.linear reference. _initialise_metal_buffers re-imports
+        # get_engine from terncore.metal_runtime each call, so patching
+        # at the source module is sufficient.
+        monkeypatch.setattr("terncore.metal_runtime.get_engine", lambda: None)
+
         torch.manual_seed(500)
         linear = nn.Linear(64, 32, bias=True)
         packed = PackedTernaryLinear.from_float(linear, threshold=0.7)

--- a/tests/test_packed_linear_metal.py
+++ b/tests/test_packed_linear_metal.py
@@ -177,3 +177,128 @@ def test_packed_layer_lazy_buffer_allocation():
 
     assert id(packed._metal_codes_buf) == codes_id
     assert id(packed._metal_scales_buf) == scales_id
+
+
+@pytest.mark.slow
+def test_production_data_e2e_gemopus():
+    """End-to-end integration on the real gemopus-4-e4b .tern-model artefact.
+
+    Loads via the decoupled path (load_as_model + key_mapping +
+    convert_model_to_packed), moves to MPS, runs 5-token generation through
+    PackedTernaryLinear.forward's Metal kernel path. Verifies the entire
+    Phase 2.5 stack works on real production data without crashing and
+    produces structurally coherent output.
+
+    The Metal-path-taken assertion verifies at least one PackedTernaryLinear
+    layer has Metal active; a stronger "most layers" assertion is deferred
+    to future work since per-layer Metal failures (e.g., K not divisible by
+    16 on some shape) are valid edge cases at this verification stage.
+
+    Skips when the artefact, Metal, MPS, or transformers/Gemma 4 are
+    unavailable. ~180-300 s runtime dominated by the 8.9 GiB artefact load
+    and the random-init 8B model construction."""
+    import gc
+    from pathlib import Path
+
+    artefact_path = Path(
+        "/Volumes/Syn Archive/models/compressed/gemopus-4-e4b/"
+        "gemopus_4_e4b_ternary_v0.1.0.tern-model/model.tern-model"
+    )
+    if not artefact_path.exists():
+        pytest.skip(f"artefact not present at {artefact_path}")
+
+    if not torch.backends.mps.is_available():
+        pytest.skip("MPS unavailable on this host")
+
+    _metal_or_skip()
+
+    try:
+        from transformers import AutoConfig, AutoTokenizer
+        import transformers
+    except ImportError:
+        pytest.skip("transformers not installed")
+
+    from terncore.tern_model import (
+        TernModelReader, GEMMA4_MULTIMODAL_TRANSFORMERS_5_5,
+    )
+    from terncore.packed_linear import PackedTernaryLinear, convert_model_to_packed
+
+    # Cheap insurance against accumulated state from prior tests in the
+    # session affecting this high-memory load.
+    gc.collect()
+
+    HF_ID = "Jackrong/Gemopus-4-E4B-it"
+
+    # Architecture from cached HF config; instantiate via the class the
+    # config declares (robust to future Gemma 4 class renames).
+    config = AutoConfig.from_pretrained(HF_ID)
+    arch_name = config.architectures[0]
+    if not hasattr(transformers, arch_name):
+        pytest.skip(f"transformers lacks {arch_name} (version mismatch)")
+    ModelClass = getattr(transformers, arch_name)
+
+    # Random-init in FP16 to fit the M4 Pro memory budget; weights are
+    # immediately overwritten by the .tern-model load.
+    model = ModelClass._from_config(config, dtype=torch.float16)
+    model.eval()
+
+    # Decoupled load: state_dict via load_as_model + key_mapping, then
+    # convert eligible Linear layers to PackedTernaryLinear.
+    reader = TernModelReader(str(artefact_path))
+    missing, unexpected = reader.load_as_model(
+        model, strict=False,
+        key_mapping=GEMMA4_MULTIMODAL_TRANSFORMERS_5_5,
+    )
+    # STATUS_PHASE2.md established baseline: 1 missing (lm_head tied),
+    # 54 unexpected (sliding-window KV pruning). Test doesn't assert exact
+    # counts (transformers version drift could shift them), only that load
+    # completed.
+
+    stats = convert_model_to_packed(model, threshold=0.7)
+    assert stats["packed_layers"] > 0, (
+        f"convert_model_to_packed produced zero packed layers: {stats}"
+    )
+
+    packed_layers = [
+        m for m in model.modules() if isinstance(m, PackedTernaryLinear)
+    ]
+    assert len(packed_layers) > 0
+
+    model = model.to("mps")
+
+    tokenizer = AutoTokenizer.from_pretrained(HF_ID)
+    messages = [{"role": "user", "content": "Hello"}]
+    prompt = tokenizer.apply_chat_template(
+        messages, tokenize=False, add_generation_prompt=True,
+    )
+    inputs = tokenizer(prompt, return_tensors="pt").to("mps")
+
+    with torch.no_grad():
+        output_ids = model.generate(
+            **inputs, max_new_tokens=5, do_sample=False,
+        )
+
+    new_tokens = output_ids[0, inputs["input_ids"].shape[1]:]
+    output_text = tokenizer.decode(new_tokens, skip_special_tokens=True)
+
+    print(f"\n[gemopus-4-e4b e2e] generated: {output_text!r}", flush=True)
+
+    assert len(output_text) > 0, "empty generation output"
+    assert any(c.isprintable() and not c.isspace() for c in output_text), (
+        f"generation output lacks printable content: {output_text!r}"
+    )
+
+    metal_path_taken = any(
+        layer._metal_buffers_initialised and layer._metal_engine is not None
+        for layer in packed_layers
+    )
+    assert metal_path_taken, (
+        "no PackedTernaryLinear layer initialised Metal buffers — "
+        "generation ran entirely through the F.linear fallback"
+    )
+
+    # Resource cleanup — release ~10 GB of MPS allocation before next test.
+    del model, packed_layers, reader, tokenizer
+    gc.collect()
+    if hasattr(torch.mps, "empty_cache"):
+        torch.mps.empty_cache()

--- a/tests/test_packed_linear_metal.py
+++ b/tests/test_packed_linear_metal.py
@@ -104,3 +104,76 @@ def test_repack_cross_kernel_equivalence(M, K):
         f"cross-kernel divergence {max_abs_diff} exceeds tolerance 0.05 "
         f"for M={M} K={K} (alpha={alpha:.4f})"
     )
+
+
+@pytest.mark.parametrize("M,K", [(64, 64), (256, 256), (2560, 2560)])
+def test_packed_layer_mps_matches_cpu(M, K):
+    """PackedTernaryLinear forward on MPS produces output equivalent to
+    forward on CPU. Exercises the new _forward_metal path end-to-end:
+    instance construction → .to("mps") → forward dispatch → output read.
+    Tolerance carries from the cross-kernel calibration (5e-2)."""
+    _metal_or_skip()
+    if not torch.backends.mps.is_available():
+        pytest.skip("MPS unavailable on this host")
+
+    import torch.nn as nn
+    from terncore.packed_linear import PackedTernaryLinear
+
+    torch.manual_seed(700)
+    linear = nn.Linear(K, M, bias=True)
+    packed_cpu = PackedTernaryLinear.from_float(linear, threshold=0.7)
+    packed_cpu.eval()
+    packed_mps = PackedTernaryLinear.from_float(linear, threshold=0.7).to("mps")
+    packed_mps.eval()
+
+    x_cpu = torch.randn(1, K)
+    x_mps = x_cpu.to("mps")
+
+    with torch.no_grad():
+        cpu_out = packed_cpu(x_cpu)
+        mps_out = packed_mps(x_mps)
+
+    assert mps_out.device.type == "mps"
+    mps_out_cpu = mps_out.cpu()
+    max_diff = (cpu_out - mps_out_cpu).abs().max().item()
+    print(f"\n[M={M} K={K}] mps vs cpu max_abs_diff={max_diff:.6f}", flush=True)
+    assert max_diff < 5e-2, (
+        f"MPS-via-Metal vs CPU divergence: {max_diff} (atol=5e-2)"
+    )
+
+
+def test_packed_layer_lazy_buffer_allocation():
+    """_metal_buffers_initialised is False before first MPS forward, True
+    after, and stays True across subsequent forwards. Codes/scales buffers
+    are non-None after init and are not re-allocated on subsequent calls."""
+    _metal_or_skip()
+    if not torch.backends.mps.is_available():
+        pytest.skip("MPS unavailable on this host")
+
+    import torch.nn as nn
+    from terncore.packed_linear import PackedTernaryLinear
+
+    torch.manual_seed(701)
+    linear = nn.Linear(64, 32, bias=False)
+    packed = PackedTernaryLinear.from_float(linear, threshold=0.7).to("mps")
+    packed.eval()
+
+    assert packed._metal_buffers_initialised is False
+    assert packed._metal_codes_buf is None
+    assert packed._metal_scales_buf is None
+
+    x = torch.randn(1, 64).to("mps")
+    with torch.no_grad():
+        _ = packed(x)
+
+    assert packed._metal_buffers_initialised is True
+    assert packed._metal_codes_buf is not None
+    assert packed._metal_scales_buf is not None
+
+    codes_id = id(packed._metal_codes_buf)
+    scales_id = id(packed._metal_scales_buf)
+    with torch.no_grad():
+        _ = packed(x)
+
+    assert id(packed._metal_codes_buf) == codes_id
+    assert id(packed._metal_scales_buf) == scales_id


### PR DESCRIPTION
## Summary

Phase 2.5 Stage 2 lands the Metal-aware forward path on `PackedTernaryLinear`, completing the integration that Stage 1 unblocked. MPS-resident inputs now dispatch through the Metal kernel via lazy-allocated GPU-resident weight buffers; CPU inputs continue through the existing C kernel fast path; fallback chains preserved through Commit 3's TypeError catch.

## Commits

- `05a549e` fix(packed_ops): catch TypeError on MPS-resident input fallback
- `3b39a69` feat(packed_linear): Metal-aware forward path for MPS inputs
- `d7693bd` test(packed_linear_metal): production-data e2e on gemopus-4-e4b

## Verification

- 400 passed, 3 skipped (no regressions from Stage 1's 395 baseline)
- Cross-kernel layer-level equivalence at M=K=64/256/2560: max_abs_diff 0.00046/0.00073/0.00069 (tighter than Stage 1's kernel-level calibration because identical from_float() construction on both sides)
- Production data e2e: 8.9 GiB gemopus-4-e4b artefact loads, MPS dispatch executes, Metal-path-taken assertion confirms at least one PackedTernaryLinear initialised Metal buffers
- Lazy buffer allocation contract verified

## Methodology

Three latent issues surfaced and resolved during this stage:
1. Commit 3 test routing (post-Commit-4 the test exercised Metal path instead of F.linear fallback) — resolved via monkeypatch preserving original coverage
2. transformers BatchEncoding API drift in test wrapper — resolved via two-step tokenisation
3. `torch_dtype` deprecation — bundled cleanup

Methodology memory `pattern_test_path_routing_change_v1` banked.

## Phase 4 (deferred)

Measurement (20-token probe + 200-token timed) on the new `terncore_packed` harness backend lands separately, followed by REPORT_PHASE2.md.