### PR TITLE
docs(CLAUDE): correct MoE IP framing — within-model zero-state ratio hypothesis

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -257,9 +257,23 @@ beyond the Apple conversation.
 compression on MoE architecture remains largely unexplored. Key
 hypothesis: inactive expert weights — those the router skips for a
 given token — cluster toward the zero-state at higher rates than
-dense layer weights. If confirmed, the ternary tolerance ratio for a
-MoE model could significantly exceed the 22.3 % achieved on
-Mistral-7B.
+dense layer weights within the same model. If confirmed, the
+per-expert zero-state ratio distribution will show a meaningful
+right-shift relative to the dense (non-expert) weights' distribution,
+providing within-model evidence for ternary's particular suitability
+to MoE expert sparsity.
+
+*(Metric note: this hypothesis is about per-tensor zero-state ratio
+under threshold quantisation. The "22.3% achieved on Llama-3.1-70B"
+figure cited in `docs/TN-001_llama70b_compression_analysis.md` is a
+distinct architectural metric — fraction of Linear modules converted
+to ternary at threshold=0.7, 20% PPL headroom (125 of 560 modules)
+— and is not directly comparable. Cross-model zero-state-ratio
+comparisons require running the analysis on each model's compressed
+manifest using the same per-tensor metric;
+`benchmarks/analyse_per_expert_tolerance.py` computes this from
+`.tern-model` manifests, with `--llama70b-manifest` providing the
+Llama-3.1-70B reference data point from the artefact on archive.)*
 
 During compression, log ternary tolerance ratio **per-expert**, not
 just the aggregate. The per-expert distribution is the IP


### PR DESCRIPTION
## Summary

Small docs correction to the "Gemma 4 26B MoE — IP opportunity" section in CLAUDE.md. The original "22.3% achieved on Mistral-7B" attribution had two errors caught during Session 2 design surface for the per-expert tolerance analysis script (PR #12):

1. **Wrong model**: 22.3% is from \`docs/TN-001_llama70b_compression_analysis.md\` reporting on Llama-3.1-70B, not Mistral-7B
2. **Wrong metric**: 22.3% is a layer-conversion rate (125/560 Linears at threshold=0.7), not zero-state ratio — fundamentally different metric than the IP claim

## Correction

New framing states the hypothesis as within-model expert vs dense zero-state ratio comparison (the right-shift in distribution), which is what the underlying science supports. Cross-model comparisons require per-manifest analysis at the same metric; the analysis script (\`benchmarks/analyse_per_expert_tolerance.py\`, PR #12) computes this with \`--llama70b-manifest\` providing the Llama-3.1-70B reference from the artefact on archive.

## Why this matters

Strategic context: this correction matters before any patent provisional drafting flows from the framing. Overclaiming significance via a non-comparable metric would surface as a prior-art characterisation error in patent prosecution. New framing anchors the IP claim in within-model evidence testable from per-tensor ternary statistics alone.

## CI

Docs-only change; no test impact.

## Coordinates with

- PR #12 — \`feat(benchmarks): per-expert tolerance analysis script + synthetic tests\` — implements the methodology referenced in the corrected framing