### PR TITLE
Session 3: per-expert tensor slicing for MoE compression

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -57,6 +57,25 @@ convention untested until Phase 2.
 
 ---
 
+### Known architecture quirk: full_attention v_proj absence (gemma4 26B-A4B)
+
+**Status:** Open (low priority, investigate later)
+**Surfaced:** 2026-05-06 Session 3 design surface for per-expert slicing
+**Observation:** The 5 full_attention layers (indices 5, 11, 17, 23, 29) carry 5 self_attn entries instead of 6 — they have no v_proj.weight, while q_proj doubles to [8192, 2816] (matches global_head_dim=512). The 25 sliding_attention layers carry 6 self_attn entries with v_proj present.
+**Hypothesis:** Full-attention layers may reuse v from an adjacent layer or via a fused projection.
+**Investigation:** Not blocking; the count formula in the Session 3 per-expert slicing rework incorporates the asymmetry. Worth confirming the architectural intent for thoroughness.
+
+---
+
+### dry_run_convert: stacked-tensor expansion not modelled
+
+**Status:** Open (low priority, informational)
+**Surfaced:** 2026-05-06 Session 3 per-expert slicing rework
+**Observation:** `dry_run_convert` (`src/terncore/convert.py`) doesn't call `adapter.expand_stacked`, so MoE stacked-experts parent tensors (e.g., `experts.gate_up_proj` shape `[128, 1408, 2816]`) appear as 3-D ternary-eligible entries in the dry-run output rather than as 128 per-expert slices. Misleading for capacity planning on MoE models but doesn't affect actual compression correctness — `full_convert` (the active path) handles expansion correctly.
+**Resolution scope:** Mirror the `stacked_plans` pattern from `full_convert` in `dry_run_convert`. Estimated 1-2 hours focused engineering. Not blocking any current work.
+
+---
+
 ## Closed
 
 ### reconstruct_all suffix-doubling — production manifest support

--- a/src/terncore/adapters/base.py
+++ b/src/terncore/adapters/base.py
@@ -43,6 +43,38 @@ class WeightClassification:
     adapter does not distinguish (default for non-hybrid models)."""
 
 
+@dataclass(frozen=True)
+class StackedSlice:
+    """One per-slice expansion record for a stacked tensor.
+
+    Stacked tensors hold N logical Linear weights packed into a single
+    safetensors entry along an axis (e.g., MoE expert weights stored as
+    ``[num_experts, out_features, in_features]`` with axis 0 = expert
+    index). Adapters return a list of ``StackedSlice`` records from
+    :meth:`ArchitectureAdapter.expand_stacked` to instruct the converter
+    how to fan one parent tensor out into N independently-quantised
+    per-slice tensors with synthesised names.
+
+    The ``slice_axis`` records how the converter must slice the loaded
+    tensor (typically 0 for axis-0 stacking). The ``slice_index`` and
+    ``synthesised_name`` are paired — the converter loops indices in
+    order and uses the matching synthesised name as the manifest entry
+    name for the resulting ternary record.
+    """
+
+    synthesised_name: str
+    """Synthesised manifest entry name for this slice
+    (e.g., ``model.language_model.layers.0.experts.5.gate_up_proj.weight``)."""
+    slice_axis: int
+    """Axis along which to slice the parent tensor (typically 0)."""
+    slice_index: int
+    """Index along ``slice_axis`` for this slice."""
+    expert_idx: Optional[int] = None
+    """Integer expert index for MoE stacked-expert tensors. For
+    expert tensors this equals ``slice_index``; ``None`` for future
+    stacked-tensor patterns that aren't expert-indexed."""
+
+
 @dataclass
 class AdapterInfo:
     """Metadata about an architecture adapter."""
@@ -108,6 +140,39 @@ class ArchitectureAdapter:
             WeightClassification with category and reason.
         """
         raise NotImplementedError
+
+    def expand_stacked(
+        self,
+        name: str,
+        shape: list[int],
+    ) -> Optional[list["StackedSlice"]]:
+        """Return per-slice expansion plan for stacked tensors.
+
+        Stacked tensors pack N logical Linear weights into a single
+        safetensors entry along one axis (typically axis 0). MoE expert
+        weights are the canonical case — e.g., Gemma 4's
+        ``experts.gate_up_proj`` of shape ``[128, 1408, 2816]`` holds
+        128 per-expert projections that benefit from independent
+        quantisation (per-expert threshold and per-expert sparsity
+        recording for IP measurement).
+
+        Args:
+            name:  HuggingFace weight name.
+            shape: Tensor shape from the safetensors header.
+
+        Returns:
+            List of :class:`StackedSlice` records when ``name`` is a
+            stacked-tensor pattern this adapter recognises, ``None``
+            otherwise (the converter then processes the tensor as a
+            single Linear weight).
+
+        Default returns ``None`` — non-MoE / dense adapters opt out
+        implicitly. MoE adapters override to declare their stacked
+        patterns. The converter calls this during shape collection
+        and during per-tensor processing; both call sites accept
+        ``None`` as "process as a single tensor".
+        """
+        return None
 
     def normalize_name(self, name: str) -> str:
         """Strip architecture-specific prefixes to get a canonical name.

--- a/src/terncore/adapters/gemma4.py
+++ b/src/terncore/adapters/gemma4.py
@@ -33,6 +33,7 @@ from terncore.adapters import register
 from terncore.adapters.base import (
     AdapterInfo,
     ArchitectureAdapter,
+    StackedSlice,
     WeightClassification,
 )
 
@@ -77,6 +78,21 @@ _ALWAYS_PROTECTED = (
     "per_layer_input_gate",
     "per_layer_projection",
 )
+
+# Stacked-experts pattern. Matches the bare safetensors entry name for
+# Gemma 4 MoE expert tensors, which pack all N experts into a single
+# 3-D safetensors entry along axis 0:
+#   model.language_model.layers.<N>.experts.gate_up_proj  [128, 1408, 2816]
+#   model.language_model.layers.<N>.experts.down_proj     [128, 2816, 704]
+# The end-anchor ``$`` distinguishes the parent stacked entry from
+# synthesised per-expert names which carry an expert index plus
+# trailing ``.weight`` (e.g., ``...experts.5.gate_up_proj.weight``).
+_STACKED_EXPERTS_RE = re.compile(r"\.experts\.(gate_up_proj|down_proj)$")
+
+# Expert index pattern. Matches synthesised per-expert names produced by
+# ``expand_stacked`` and populates ``WeightClassification.expert_idx``
+# via the base helper :meth:`ArchitectureAdapter._extract_expert_idx`.
+_EXPERT_IDX_RE = re.compile(r"\.experts\.(?P<expert_idx>\d+)\.")
 
 
 @register("gemma4")
@@ -124,7 +140,49 @@ class Gemma4Adapter(ArchitectureAdapter):
             protection_patterns=list(_ALWAYS_PROTECTED),
             multimodal=True,
             multimodal_components=["vision", "audio", "projector"],
+            expert_pattern=_EXPERT_IDX_RE,
         )
+
+    def expand_stacked(
+        self,
+        name: str,
+        shape: list[int],
+    ) -> Optional[list[StackedSlice]]:
+        """Fan stacked MoE expert tensors out into per-expert slices.
+
+        Recognises Gemma 4's two stacked-experts patterns
+        (``experts.gate_up_proj`` and ``experts.down_proj``) by the
+        bare safetensors name (no expert index, no ``.weight`` suffix).
+        Returns one :class:`StackedSlice` per expert slot along axis 0,
+        with synthesised names of the form
+        ``...experts.<K>.<projection>.weight``. Returns ``None`` for
+        non-stacked weights so dense / attention / multimodal tensors
+        flow through the converter unchanged.
+        """
+        match = _STACKED_EXPERTS_RE.search(name)
+        if match is None:
+            return None
+        if len(shape) != 3:
+            raise ValueError(
+                f"Gemma4Adapter recognised '{name}' as a stacked-experts "
+                f"pattern but shape {shape} is not 3-D. Expected "
+                f"[num_experts, ..., ...] — refusing to fan out with "
+                f"unknown stacking layout."
+            )
+        projection = match.group(1)  # "gate_up_proj" or "down_proj"
+        num_experts = shape[0]
+        # Strip trailing "<projection>" (last segment) so the prefix ends
+        # in ".experts." — synthesised per-expert names slot the index in.
+        prefix = name[: -len(projection)]
+        return [
+            StackedSlice(
+                synthesised_name=f"{prefix}{k}.{projection}.weight",
+                slice_axis=0,
+                slice_index=k,
+                expert_idx=k,
+            )
+            for k in range(num_experts)
+        ]
 
     def normalize_name(self, name: str) -> str:
         """Strip the ``language_model.`` prefix from multimodal weight names.
@@ -150,6 +208,7 @@ class Gemma4Adapter(ArchitectureAdapter):
         """Classify a weight tensor for conversion."""
         canonical = self.normalize_name(name)
         component = self._detect_component(name)
+        expert_idx = self._extract_expert_idx(name)
 
         # Rule 1–2: Non-language components → FP16-retain
         if component == "vision":
@@ -159,6 +218,7 @@ class Gemma4Adapter(ArchitectureAdapter):
                 category="fp16_retain",
                 reason="Vision encoder — modality encoders are FP16-retain",
                 component=component,
+                expert_idx=expert_idx,
             )
         if component == "audio":
             return WeightClassification(
@@ -167,6 +227,7 @@ class Gemma4Adapter(ArchitectureAdapter):
                 category="fp16_retain",
                 reason="Audio encoder — modality encoders are FP16-retain",
                 component=component,
+                expert_idx=expert_idx,
             )
         if component == "projector":
             return WeightClassification(
@@ -175,6 +236,7 @@ class Gemma4Adapter(ArchitectureAdapter):
                 category="fp16_retain",
                 reason="Multi-modal projector — cross-modal alignment is precision-sensitive",
                 component=component,
+                expert_idx=expert_idx,
             )
 
         # Rule 3: Always-protected language weights
@@ -187,6 +249,7 @@ class Gemma4Adapter(ArchitectureAdapter):
                     category="fp16_retain",
                     reason=f"Protected pattern: '{pattern}'",
                     component=component,
+                    expert_idx=expert_idx,
                 )
 
         # Rule 4: 1-D weights (biases, scalars) → FP16-retain
@@ -197,6 +260,7 @@ class Gemma4Adapter(ArchitectureAdapter):
                 category="fp16_retain",
                 reason="1-D tensor (bias or scalar parameter)",
                 component=component,
+                expert_idx=expert_idx,
             )
 
         # Rule 5: Remaining 2-D weights → ternary-eligible
@@ -206,4 +270,5 @@ class Gemma4Adapter(ArchitectureAdapter):
             category="ternary_eligible",
             reason="2-D weight in transformer block — eligible for ternary conversion",
             component=component,
+            expert_idx=expert_idx,
         )

--- a/src/terncore/convert.py
+++ b/src/terncore/convert.py
@@ -39,6 +39,7 @@ from typing import Optional
 import torch
 import torch.nn as nn
 
+from terncore.adapters.base import StackedSlice
 from terncore.arithmetic.quantizer import TernaryQuantizer
 from terncore.sparse import pack_ternary_weights
 from terncore.tern_model import TernModelWriter, TernModelReader
@@ -619,6 +620,12 @@ def full_convert(
     # ── Get shapes and classify ──
     _log(f"\n  Reading weight shapes...")
     weight_shapes: dict[str, list[int]] = {}
+    # Stacked-tensor expansion plan: maps each safetensors entry name that
+    # the adapter recognises as a stacked-tensor pattern (e.g., MoE
+    # ``experts.gate_up_proj``) to the list of per-slice StackedSlice
+    # records the per-tensor processing loop will fan it out into. Entries
+    # absent from this dict are processed as single tensors.
+    stacked_plans: dict[str, list[StackedSlice]] = {}
     # Group by file for efficient reading
     file_to_keys: dict[Path, list[str]] = {}
     for wname, fpath in weight_to_file.items():
@@ -627,7 +634,23 @@ def full_convert(
     for fpath, keys in file_to_keys.items():
         with safe_open(str(fpath), framework="pt", device="cpu") as f:
             for key in keys:
-                weight_shapes[key] = list(f.get_slice(key).get_shape())
+                parent_shape = list(f.get_slice(key).get_shape())
+                plan = adapter.expand_stacked(key, parent_shape)
+                if plan is None:
+                    weight_shapes[key] = parent_shape
+                else:
+                    stacked_plans[key] = plan
+                    per_slice_shape = [
+                        s for i, s in enumerate(parent_shape)
+                        if i != plan[0].slice_axis
+                    ]
+                    for slice_record in plan:
+                        weight_shapes[slice_record.synthesised_name] = list(per_slice_shape)
+
+    if stacked_plans:
+        _expanded = sum(len(p) for p in stacked_plans.values())
+        _log(f"  Stacked-tensor expansion: {len(stacked_plans)} parents → "
+             f"{_expanded} per-slice entries")
 
     _log(f"  Classifying {len(weight_shapes)} weights...")
     classifications = adapter.classify_all(weight_shapes)
@@ -690,11 +713,63 @@ def full_convert(
         "fp16_layers": 0, "fp16_params": 0,
     }
 
-    # Process file by file to minimise open/close overhead
+    # Process file by file to minimise open/close overhead.
+    # Stacked tensors (per ``stacked_plans``) are loaded once then sliced
+    # along the recorded axis; each per-expert slice is quantised
+    # independently so the resulting manifest carries per-expert
+    # threshold / alpha / sparsity (the IP measurement granularity).
+    # The inner slice loop emits all per-expert records for one parent
+    # contiguously before the outer loop advances to the next safetensors
+    # key — this contiguity is what bounds reader-side restack memory
+    # in TernModelReader.reconstruct_all to one parent at a time.
     for fpath, keys in file_to_keys.items():
         with safe_open(str(fpath), framework="pt", device="cpu") as f:
             for wname in sorted(keys):
                 tensor = f.get_tensor(wname)
+
+                if wname in stacked_plans:
+                    # Stacked tensor — fan out to per-slice ternary records.
+                    # All slices route to ternary by design: per-expert MoE
+                    # weights are precisely the IP measurement target. INT4
+                    # / FP16 routing for stacked patterns is not currently
+                    # supported (no use case; would require per-slice
+                    # routing decisions surfaced from the sensitivity map).
+                    plan = stacked_plans[wname]
+                    parent_canonical = adapter.normalize_name(wname)
+                    stack_total = len(plan)
+                    for slice_record in plan:
+                        slice_tensor = tensor.select(
+                            slice_record.slice_axis, slice_record.slice_index
+                        ).contiguous()
+                        slice_shape = list(slice_tensor.shape)
+                        slice_params = slice_tensor.numel()
+                        packed, alpha, bitmap, sparsity = (
+                            TernModelWriter.pack_ternary(
+                                slice_tensor.float(), threshold
+                            )
+                        )
+                        writer.add_ternary_layer(
+                            name=adapter.normalize_name(slice_record.synthesised_name),
+                            packed_weights=packed,
+                            alpha=alpha,
+                            shape=slice_shape,
+                            sparsity_bitmap=bitmap,
+                            threshold=threshold,
+                            sparsity=sparsity,
+                            stacked_parent=parent_canonical,
+                            stack_axis=slice_record.slice_axis,
+                            stack_index=slice_record.slice_index,
+                            stack_total=stack_total,
+                        )
+                        stats["ternary_layers"] += 1
+                        stats["ternary_params"] += slice_params
+                        del slice_tensor
+                        done += 1
+                        if done % 100 == 0 or done == total_weights:
+                            _log(f"    [{done}/{total_weights}] processed")
+                    del tensor
+                    continue
+
                 shape = list(tensor.shape)
                 num_params = tensor.numel()
                 canonical = adapter.normalize_name(wname)

--- a/src/terncore/tern_model.py
+++ b/src/terncore/tern_model.py
@@ -1035,18 +1035,90 @@ class TernModelReader:
         """
         Reconstruct all layers as a flat state_dict-compatible dict.
 
-        Supports two manifest conventions detected per-entry by suffix:
+        Supports three manifest conventions detected per-entry:
         - Test convention: bare layer names (e.g. "fc1"). Method appends
           ".weight" / ".bias" suffixes to produce parameter keys.
         - Production convention: names already include parameter/buffer
           suffix (".weight", ".input_max", etc.). Method uses names as-is.
+        - Stacked convention: entries with ``stacked_parent`` metadata
+          represent per-slice records of a stacked tensor (e.g., per-expert
+          slices of a Gemma 4 MoE ``experts.gate_up_proj``). Method
+          accumulates slices in-flight per parent and restacks immediately
+          when the per-parent slice count reaches ``stack_total``, freeing
+          the slice list before continuing iteration. The state_dict key
+          is the ``stacked_parent`` value verbatim.
+
+        Memory envelope for stacked entries: at most one parent's worth of
+        slices is held in memory at any time (~2 GB for a 26B-A4B
+        ``experts.gate_up_proj`` with 128 per-expert slices at FP32). This
+        relies on the writer (``convert.py:full_convert``) emitting all
+        slices for one parent contiguously in the manifest before moving
+        to the next stacked tensor — which it does because each stacked
+        parent is processed in a single inner loop.
+
+        Raises:
+            ValueError: when stacked-slice metadata is inconsistent within
+                a parent group (mismatched axes/totals), the slice count
+                doesn't match ``stack_total``, slice indices are not a
+                contiguous ``0..N-1`` range, or the manifest exhausts
+                with incomplete stacked-parent groups. Loud failure
+                preferred over silent reconstruction with missing slices.
 
         Returns:
             Dict mapping parameter/buffer keys to reconstructed tensors.
         """
         state_dict: dict[str, torch.Tensor] = {}
+        # In-flight stacked-parent slices: parent_name → list of
+        # (stack_index, tensor, stack_axis, stack_total). Entries removed
+        # from this dict immediately after restacking to bound memory.
+        stacked_groups: dict[str, list[tuple[int, torch.Tensor, int, int]]] = {}
+
         for entry in self.manifest["layers"]:
             name = entry["name"]
+            stacked_parent = entry.get("stacked_parent")
+            if stacked_parent is not None:
+                tensors = self.reconstruct_layer(name)
+                slices = stacked_groups.setdefault(stacked_parent, [])
+                slices.append((
+                    entry["stack_index"],
+                    tensors["weight"],
+                    entry["stack_axis"],
+                    entry["stack_total"],
+                ))
+                stack_total = entry["stack_total"]
+                if len(slices) == stack_total:
+                    # Group complete — validate, restack, emit, free.
+                    axes = {s[2] for s in slices}
+                    totals = {s[3] for s in slices}
+                    if len(axes) != 1 or len(totals) != 1:
+                        raise ValueError(
+                            f"Stacked-parent '{stacked_parent}' has inconsistent "
+                            f"slice metadata: axes={axes}, totals={totals}."
+                        )
+                    stack_axis = axes.pop()
+                    actual_total = totals.pop()
+                    if len(slices) != actual_total:
+                        raise ValueError(
+                            f"Stacked-parent '{stacked_parent}' incomplete: "
+                            f"expected {actual_total} slices, got {len(slices)}."
+                        )
+                    slices.sort(key=lambda s: s[0])
+                    actual_indices = [s[0] for s in slices]
+                    expected_indices = list(range(actual_total))
+                    if actual_indices != expected_indices:
+                        raise ValueError(
+                            f"Stacked-parent '{stacked_parent}' has non-contiguous "
+                            f"slice indices: expected {expected_indices}, "
+                            f"got {actual_indices}."
+                        )
+                    slice_tensors = [s[1] for s in slices]
+                    state_dict[stacked_parent] = torch.stack(
+                        slice_tensors, dim=stack_axis
+                    )
+                    # Free the per-slice tensors before continuing iteration.
+                    slices.clear()
+                    del stacked_groups[stacked_parent]
+                continue
             tensors = self.reconstruct_layer(name)
             if name.endswith(_PRODUCTION_NAME_SUFFIXES):
                 # Production convention: name is already a parameter/buffer key
@@ -1059,6 +1131,17 @@ class TernModelReader:
                 state_dict[f"{name}.weight"] = tensors["weight"]
                 if "bias" in tensors:
                     state_dict[f"{name}.bias"] = tensors["bias"]
+
+        # Any stacked groups still present here are incomplete — the writer
+        # never finished emitting all their slices. Loud failure rather than
+        # silent partial reconstruction.
+        if stacked_groups:
+            leftover = {p: f"{len(s)}/{s[0][3]}" for p, s in stacked_groups.items()}
+            raise ValueError(
+                f"Manifest exhausted with incomplete stacked-parent groups: "
+                f"{leftover}. Each parent reports (slices_seen / stack_total)."
+            )
+
         return state_dict
 
     def load_as_model(

--- a/src/terncore/tern_model.py
+++ b/src/terncore/tern_model.py
@@ -183,6 +183,11 @@ class TernModelWriter:
         alpha: float,
         shape: list[int],
         sparsity_bitmap: Optional[bytes] = None,
+        *,
+        stacked_parent: Optional[str] = None,
+        stack_axis: Optional[int] = None,
+        stack_index: Optional[int] = None,
+        stack_total: Optional[int] = None,
         **metadata: Any,
     ) -> None:
         """
@@ -194,6 +199,22 @@ class TernModelWriter:
             alpha:           Per-layer scaling factor.
             shape:           Original weight shape, e.g. [2048, 2048].
             sparsity_bitmap: Optional sparsity bitmap bytes.
+            stacked_parent:  When this layer is one slice of a stacked tensor
+                             (e.g., a per-expert slice of a Gemma 4 MoE
+                             ``experts.gate_up_proj``), the bare safetensors
+                             entry name of the parent stacked tensor. The
+                             reader's ``reconstruct_all`` uses this to group
+                             slices and restack into the parent's 3-D shape.
+                             All four stacking fields are mutually required —
+                             either all four are provided (stacked slice case)
+                             or none are (standard tensor case). Mixed states
+                             raise ValueError.
+            stack_axis:      Axis along which the parent tensor was sliced
+                             (typically 0 for axis-0 stacked experts).
+            stack_index:     This slice's index along ``stack_axis``.
+            stack_total:     Total number of slices in the parent stack
+                             (used by the reader to verify completeness
+                             before restacking).
             **metadata:      Additional fields (threshold, sparsity, sensitivity_score,
                             quant_error, bias as torch.Tensor, etc.).
         """
@@ -209,7 +230,19 @@ class TernModelWriter:
             has_bias = True
             bias_bytes = bias_tensor.detach().float().numpy().tobytes()
 
-        self._layers.append({
+        # Stacking metadata: enforce all-four-or-none invariant. Convert.py
+        # builds these from a StackedSlice dataclass so they always arrive
+        # together; defensive guard catches future call sites that drift.
+        stacking_fields = (stacked_parent, stack_axis, stack_index, stack_total)
+        stacking_set = sum(1 for f in stacking_fields if f is not None)
+        if stacking_set not in (0, 4):
+            raise ValueError(
+                f"add_ternary_layer stacking metadata must be all-set or all-None; "
+                f"got stacked_parent={stacked_parent!r}, stack_axis={stack_axis!r}, "
+                f"stack_index={stack_index!r}, stack_total={stack_total!r}."
+            )
+
+        record = {
             "name": name,
             "dtype": "ternary2",
             "shape": shape,
@@ -225,7 +258,17 @@ class TernModelWriter:
             "_packed": packed_weights,
             "_bitmap": sparsity_bitmap,
             "_bias": bias_bytes,
-        })
+        }
+        # Stacking metadata included only when present — preserves byte-for-byte
+        # compatibility with pre-rework manifests and avoids null-spam across
+        # the ~7,800 per-expert entries of a 26B-A4B compressed manifest.
+        if stacked_parent is not None:
+            record["stacked_parent"] = stacked_parent
+            record["stack_axis"] = stack_axis
+            record["stack_index"] = stack_index
+            record["stack_total"] = stack_total
+
+        self._layers.append(record)
 
     def add_int4_layer(
         self,

--- a/tests/test_adapters_schema_widening.py
+++ b/tests/test_adapters_schema_widening.py
@@ -180,12 +180,19 @@ def test_detect_attention_type_returns_full_when_pattern_misses():
 
 @pytest.mark.parametrize(
     "adapter_cls",
-    [LlamaAdapter, Gemma3Adapter, Gemma4Adapter],
+    [LlamaAdapter, Gemma3Adapter],
 )
 def test_existing_adapters_have_none_for_new_info_fields(adapter_cls):
-    """Smoke positive: llama/gemma3/gemma4 declare neither
-    expert_pattern nor attention_type_pattern. The schema widening
-    must be a pure-additive no-op for non-MoE, non-hybrid adapters.
+    """Smoke positive: llama/gemma3 declare neither expert_pattern nor
+    attention_type_pattern. The Group A schema widening must be a
+    pure-additive no-op for non-MoE, non-hybrid adapters.
+
+    Gemma4Adapter was excluded from this list during the Session 3
+    per-expert slicing rework — it now legitimately declares an
+    ``expert_pattern`` so the inherited ``_extract_expert_idx`` helper
+    can populate ``WeightClassification.expert_idx`` from synthesised
+    per-expert names. That declaration is exercised by tests in
+    ``test_gemma4_adapter_stacked.py``.
     """
     info = adapter_cls().info()
     assert info.expert_pattern is None

--- a/tests/test_e4b_regression.py
+++ b/tests/test_e4b_regression.py
@@ -1,0 +1,159 @@
+"""
+E4B regression tests against the on-disk Gemopus-4-E4B baseline artefact.
+
+Verifies that pre-rework .tern-model artefacts continue to read cleanly
+after the Session 3 per-expert slicing rework. The baseline at
+``/Volumes/Syn Archive/models/compressed/gemopus-4-e4b/`` was sealed
+before the rework landed, so:
+
+- It carries no ``stacked_parent`` metadata on any entry.
+- Reading via the post-rework ``TernModelReader.reconstruct_all`` must
+  produce a state_dict identical in structure to what the pre-rework
+  reader would have produced (no accidental restacking-path entry).
+
+Tests 1-3 run by default and auto-skip if the archive isn't mounted
+(catches schema-breaking changes on every test cycle for developers
+with the archive available).
+
+Test 4 is opt-in via ``RUN_E4B_REGRESSION=1`` env var AND requires
+E4B source weights at ``/Volumes/Syn Archive/models/source/gemma-4-e4b-it/``.
+When enabled it re-runs ``full_convert`` against the source and diffs
+the resulting manifest against the baseline. This is the canonical
+heavy validation banked for Substep 2g manual execution.
+
+Copyright (c) 2025–2026 Gamma Seeds Pte Ltd. All rights reserved.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from terncore.tern_model import TernModelReader
+
+
+BASELINE_PATH = Path(
+    "/Volumes/Syn Archive/models/compressed/gemopus-4-e4b/"
+    "gemopus_4_e4b_ternary_v0.1.0.tern-model/model.tern-model"
+)
+E4B_SOURCE_PATH = Path("/Volumes/Syn Archive/models/source/gemma-4-e4b-it")
+
+
+_baseline_skip = pytest.mark.skipif(
+    not BASELINE_PATH.exists(),
+    reason=f"E4B baseline artefact not present at {BASELINE_PATH} "
+           f"(Syn Archive likely not mounted on this host).",
+)
+
+
+# ── Tests 1–3: baseline backwards-compat (auto-skip if archive missing) ─
+
+
+@_baseline_skip
+def test_baseline_manifest_reads_cleanly():
+    """Pre-rework E4B baseline opens via post-rework TernModelReader.
+
+    Catches schema-breaking changes that would prevent loading existing
+    .tern-model artefacts. The baseline is a real production artefact
+    sealed before the Session 3 rework.
+    """
+    reader = TernModelReader(str(BASELINE_PATH))
+    entries = reader.manifest["layers"]
+    assert len(entries) > 0, (
+        f"Baseline manifest has no entries: {BASELINE_PATH}"
+    )
+
+
+@_baseline_skip
+def test_baseline_has_no_stacking_metadata():
+    """Pre-rework baseline must carry no ``stacked_parent`` field.
+
+    Two purposes:
+    - Confirms the baseline is genuinely pre-rework (sanity check).
+    - Confirms pre-rework manifests don't accidentally trigger the new
+      restacking path on read — the restacking branch is gated on
+      ``entry.get("stacked_parent")`` returning a non-None value.
+    """
+    reader = TernModelReader(str(BASELINE_PATH))
+    entries = reader.manifest["layers"]
+    offenders = [e["name"] for e in entries if "stacked_parent" in e]
+    assert not offenders, (
+        f"Baseline manifest contains {len(offenders)} entries with stacking "
+        f"metadata, but baseline was sealed pre-rework: {offenders[:5]}"
+    )
+
+
+@pytest.mark.slow
+@_baseline_skip
+def test_baseline_reconstruct_all_succeeds():
+    """End-to-end backwards-compat: reconstruct_all walks the entire
+    baseline manifest and emits a state_dict.
+
+    Catches restacking-path crashes on real artefacts (the in-flight
+    accumulator should never enter the stacked branch since no entry
+    carries ``stacked_parent``, but a regression in the gating logic
+    would surface here).
+    """
+    reader = TernModelReader(str(BASELINE_PATH))
+    state_dict = reader.reconstruct_all()
+    # Sanity bound: E4B is a multi-billion-parameter model; expect
+    # hundreds of state_dict entries (layers × projections + embeds + norms).
+    assert len(state_dict) > 100, (
+        f"reconstruct_all produced only {len(state_dict)} state_dict entries "
+        f"from baseline — suspiciously low for E4B."
+    )
+
+
+# ── Test 4: active re-compression diff (opt-in, slow) ───────────────
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(
+    os.getenv("RUN_E4B_REGRESSION") != "1",
+    reason="Set RUN_E4B_REGRESSION=1 to enable the slow active "
+           "re-compression diff (~45 min wall clock).",
+)
+@pytest.mark.skipif(
+    not E4B_SOURCE_PATH.exists(),
+    reason=f"E4B source weights not present at {E4B_SOURCE_PATH}; "
+           f"required for active re-compression.",
+)
+@_baseline_skip
+def test_e4b_active_recompression_diff(tmp_path: Path):
+    """Re-compress E4B source through the post-rework pipeline and diff
+    the resulting manifest against the baseline.
+
+    Modulo timestamp + non-deterministic metadata, the manifest entry
+    list (names + dtypes + shapes) must match the baseline entry-for-entry.
+    Any divergence indicates the rework changed dense-model behaviour.
+
+    This is the canonical heavy regression test for the rework. Banked
+    for Substep 2g manual execution; not in default CI.
+    """
+    from terncore.convert import full_convert
+
+    out_dir = tmp_path / "e4b_recompress"
+    full_convert(
+        model_id=str(E4B_SOURCE_PATH),
+        adapter_name="gemma4",
+        output_dir=str(out_dir),
+        threshold=0.7,
+        verbose=False,
+    )
+
+    fresh = TernModelReader(str(out_dir / "model.tern-model"))
+    baseline = TernModelReader(str(BASELINE_PATH))
+
+    fresh_keys = sorted(
+        (e["name"], e["dtype"], tuple(e["shape"])) for e in fresh.manifest["layers"]
+    )
+    baseline_keys = sorted(
+        (e["name"], e["dtype"], tuple(e["shape"])) for e in baseline.manifest["layers"]
+    )
+    assert fresh_keys == baseline_keys, (
+        f"E4B re-compression diff: {len(set(fresh_keys) ^ set(baseline_keys))} "
+        f"entries differ between fresh and baseline manifests."
+    )

--- a/tests/test_full_convert_per_expert.py
+++ b/tests/test_full_convert_per_expert.py
@@ -1,0 +1,347 @@
+"""
+End-to-end tests for per-expert slicing in ``convert.py:full_convert``.
+
+Session 3 per-expert slicing rework: ``full_convert`` calls
+``adapter.expand_stacked`` during shape collection, then in the per-tensor
+processing loop slices the parent stacked tensor along ``stack_axis``
+and quantises each slice independently. The resulting manifest holds
+one ternary entry per expert with stacking metadata (``stacked_parent``,
+``stack_axis``, ``stack_index``, ``stack_total``).
+
+These tests build a tiny synthetic Gemma 4 fixture under ``tmp_path``
+(no HuggingFace downloads), run it through ``full_convert``, and inspect
+the resulting ``.tern-model`` manifest.
+
+Copyright (c) 2025–2026 Gamma Seeds Pte Ltd. All rights reserved.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import torch
+from safetensors.torch import save_file
+
+from terncore.adapters.gemma4 import Gemma4Adapter
+from terncore.convert import full_convert
+from terncore.tern_model import TernModelReader
+
+
+# ── Synthetic fixture builder ───────────────────────────────────────
+
+
+def _write_synthetic_gemma4_model(
+    model_dir: Path,
+    *,
+    include_stacked_experts: bool,
+    num_experts: int = 4,
+    expert_out_dim: int = 8,
+    expert_in_dim: int = 16,
+    seed: int = 1234,
+) -> dict[str, list[int]]:
+    """Build a minimal Gemma 4-shaped safetensors model under ``model_dir``.
+
+    Writes ``config.json`` (with the architecture name + model_type +
+    minimal text_config so adapter.validate_architecture passes cleanly)
+    plus a single-shard ``model.safetensors`` containing a small set of
+    representative tensors. Returns the dict of ``name -> shape`` so
+    tests can cross-check against the manifest.
+
+    The stacked-expert tensor (when included) is constructed with
+    distinct content per expert slot (``slot_k = 0.5*k + randn``) so
+    per-expert sparsity values come out distinct after quantisation —
+    this is what lets test 2 distinguish per-expert quantisation from a
+    silent shared-threshold degradation.
+    """
+    model_dir.mkdir(parents=True, exist_ok=True)
+    torch.manual_seed(seed)
+
+    tensors: dict[str, torch.Tensor] = {}
+
+    if include_stacked_experts:
+        # Stacked-experts parent: [num_experts, out, in]. Each slot
+        # offset by a distinct mean so per-expert sparsity differs.
+        slots = []
+        for k in range(num_experts):
+            slot = 0.5 * k + torch.randn(expert_out_dim, expert_in_dim)
+            slots.append(slot)
+        tensors["model.language_model.layers.0.experts.gate_up_proj"] = (
+            torch.stack(slots, dim=0)
+        )
+
+    # Dense MLP weight (ternary_eligible, non-stacked)
+    tensors["model.language_model.layers.0.mlp.gate_proj.weight"] = torch.randn(
+        expert_in_dim, expert_in_dim
+    )
+    # Attention weight (ternary_eligible, non-stacked)
+    tensors["model.language_model.layers.0.self_attn.q_proj.weight"] = torch.randn(
+        expert_in_dim, expert_in_dim
+    )
+    # Norm (fp16_retain via Rule 3 protected pattern)
+    tensors["model.language_model.layers.0.input_layernorm.weight"] = torch.randn(
+        expert_in_dim
+    )
+    # Embed (fp16_retain via Rule 3 protected pattern)
+    tensors["model.language_model.embed_tokens.weight"] = torch.randn(
+        32, expert_in_dim
+    )
+
+    save_file(tensors, str(model_dir / "model.safetensors"))
+
+    config = {
+        "architectures": ["Gemma4ForConditionalGeneration"],
+        "model_type": "gemma4",
+        "text_config": {
+            "num_hidden_layers": 1,
+            "hidden_size": expert_in_dim,
+            "num_experts": num_experts,
+            "moe_intermediate_size": expert_out_dim // 2,
+        },
+    }
+    (model_dir / "config.json").write_text(json.dumps(config, indent=2))
+
+    # Defensive: validate that the synthetic config will pass the adapter's
+    # architecture check before the test exercises any conversion logic.
+    # Surfaces fixture errors as clear AssertionError rather than confusing
+    # downstream failures.
+    Gemma4Adapter().validate_architecture(config["architectures"][0])
+
+    return {name: list(t.shape) for name, t in tensors.items()}
+
+
+def _read_manifest(tern_model_path: Path) -> list[dict]:
+    """Return the manifest entries from a written .tern-model artefact."""
+    return TernModelReader(str(tern_model_path)).manifest["layers"]
+
+
+# ── Tests ───────────────────────────────────────────────────────────
+
+
+def test_full_convert_expands_stacked_experts(tmp_path: Path):
+    """4 stacked-slice entries with stacking metadata + 4 non-stacked entries."""
+    model_dir = tmp_path / "synthetic_model"
+    out_dir = tmp_path / "out"
+    _write_synthetic_gemma4_model(
+        model_dir, include_stacked_experts=True, num_experts=4
+    )
+
+    full_convert(
+        model_id=str(model_dir),
+        adapter_name="gemma4",
+        output_dir=str(out_dir),
+        threshold=0.7,
+        verbose=False,
+    )
+
+    entries = _read_manifest(out_dir / "model.tern-model")
+
+    stacked_entries = [e for e in entries if e.get("stacked_parent")]
+    non_stacked = [e for e in entries if not e.get("stacked_parent")]
+
+    assert len(stacked_entries) == 4, (
+        f"Expected 4 per-expert slices, got {len(stacked_entries)}"
+    )
+
+    # Per-slice metadata is correct, indices are 0..3 contiguous
+    assert all(e["stack_total"] == 4 for e in stacked_entries)
+    assert all(e["stack_axis"] == 0 for e in stacked_entries)
+    indices = sorted(e["stack_index"] for e in stacked_entries)
+    assert indices == [0, 1, 2, 3]
+
+    # Synthesised names follow the expected template
+    for entry in stacked_entries:
+        k = entry["stack_index"]
+        assert entry["name"] == (
+            f"model.layers.0.experts.{k}.gate_up_proj.weight"
+        )
+        # stacked_parent is the post-normalize_name canonical form
+        assert entry["stacked_parent"] == "model.layers.0.experts.gate_up_proj"
+
+    # Non-stacked: 2 ternary (mlp.gate_proj, self_attn.q_proj) + 2 fp16
+    # (input_layernorm, embed_tokens). Norm + embed → float16 dtype.
+    ternary_non_stacked = [e for e in non_stacked if e["dtype"] == "ternary2"]
+    fp16_non_stacked = [e for e in non_stacked if e["dtype"] == "float16"]
+    assert len(ternary_non_stacked) == 2
+    assert len(fp16_non_stacked) == 2
+
+
+def test_full_convert_per_expert_sparsity_distinct(tmp_path: Path):
+    """Per-expert sparsity values are distinct (IP measurement validation).
+
+    Distinguishes per-expert quantisation (each slice gets its own
+    threshold-derived cutoff) from a silent shared-threshold degradation
+    that would produce identical sparsity values across slices.
+    """
+    model_dir = tmp_path / "synthetic_model"
+    out_dir = tmp_path / "out"
+    _write_synthetic_gemma4_model(
+        model_dir, include_stacked_experts=True, num_experts=4
+    )
+
+    full_convert(
+        model_id=str(model_dir),
+        adapter_name="gemma4",
+        output_dir=str(out_dir),
+        threshold=0.7,
+        verbose=False,
+    )
+
+    entries = _read_manifest(out_dir / "model.tern-model")
+    stacked_entries = [e for e in entries if e.get("stacked_parent")]
+    sparsity_values = [entry["sparsity"] for entry in stacked_entries]
+
+    assert len(set(round(s, 6) for s in sparsity_values)) == len(sparsity_values), (
+        f"Per-expert sparsity values not distinct: {sparsity_values}"
+    )
+
+
+def test_full_convert_dense_path_unchanged_for_non_stacked(tmp_path: Path):
+    """Non-stacked tensors carry no stacking metadata in the manifest."""
+    model_dir = tmp_path / "synthetic_model"
+    out_dir = tmp_path / "out"
+    _write_synthetic_gemma4_model(
+        model_dir, include_stacked_experts=True, num_experts=4
+    )
+
+    full_convert(
+        model_id=str(model_dir),
+        adapter_name="gemma4",
+        output_dir=str(out_dir),
+        threshold=0.7,
+        verbose=False,
+    )
+
+    entries = _read_manifest(out_dir / "model.tern-model")
+    for entry in entries:
+        if entry["name"] in (
+            "model.layers.0.mlp.gate_proj.weight",
+            "model.layers.0.self_attn.q_proj.weight",
+        ):
+            assert "stacked_parent" not in entry, (
+                f"Non-stacked entry '{entry['name']}' carries stacking metadata"
+            )
+
+
+def test_full_convert_no_stacking_metadata_for_dense_only_model(tmp_path: Path):
+    """E4B regression: dense-only model produces no stacking metadata.
+
+    When the source has no ``experts.*`` tensors at all, every manifest
+    entry must lack ``stacked_parent``. This is the most important
+    regression case — confirms the rework adds zero overhead and zero
+    behaviour change for dense models.
+    """
+    model_dir = tmp_path / "dense_model"
+    out_dir = tmp_path / "out"
+    shapes = _write_synthetic_gemma4_model(
+        model_dir, include_stacked_experts=False
+    )
+    assert "model.language_model.layers.0.experts.gate_up_proj" not in shapes
+
+    full_convert(
+        model_id=str(model_dir),
+        adapter_name="gemma4",
+        output_dir=str(out_dir),
+        threshold=0.7,
+        verbose=False,
+    )
+
+    entries = _read_manifest(out_dir / "model.tern-model")
+    for entry in entries:
+        assert "stacked_parent" not in entry, (
+            f"Dense-only model produced stacking metadata on entry "
+            f"'{entry['name']}' — regression in non-MoE path."
+        )
+
+    # And the entry count equals what we wrote (no expansion)
+    assert len(entries) == len(shapes), (
+        f"Dense-only entry count drifted: wrote {len(shapes)}, "
+        f"manifest has {len(entries)}."
+    )
+
+
+def test_full_convert_round_trip_restacking(tmp_path: Path):
+    """End-to-end: write → reconstruct_all returns the parent under the
+    canonical key with the expected restacked shape."""
+    model_dir = tmp_path / "synthetic_model"
+    out_dir = tmp_path / "out"
+    _write_synthetic_gemma4_model(
+        model_dir, include_stacked_experts=True, num_experts=4,
+        expert_out_dim=8, expert_in_dim=16,
+    )
+
+    full_convert(
+        model_id=str(model_dir),
+        adapter_name="gemma4",
+        output_dir=str(out_dir),
+        threshold=0.7,
+        verbose=False,
+    )
+
+    reader = TernModelReader(str(out_dir / "model.tern-model"))
+    state_dict = reader.reconstruct_all()
+
+    parent_key = "model.layers.0.experts.gate_up_proj"
+    assert parent_key in state_dict, (
+        f"Restacked parent missing from state_dict; keys: {sorted(state_dict)}"
+    )
+    restacked = state_dict[parent_key]
+    assert restacked.shape == torch.Size([4, 8, 16]), (
+        f"Restacked shape wrong: expected [4, 8, 16], got {list(restacked.shape)}"
+    )
+
+    # And the per-slice synthesised names should NOT appear in state_dict —
+    # they were consumed during restacking and emitted under the parent name only.
+    for k in range(4):
+        synth = f"model.layers.0.experts.{k}.gate_up_proj.weight"
+        assert synth not in state_dict, (
+            f"Synthesised slice name '{synth}' leaked into state_dict alongside "
+            f"the restacked parent — restacking should consume the slices."
+        )
+
+
+def test_full_convert_stacked_parent_uses_normalized_name(tmp_path: Path):
+    """``stacked_parent`` field is the post-normalize_name canonical form.
+
+    Both the per-slice ``name`` and the ``stacked_parent`` reference must
+    travel through ``adapter.normalize_name`` so they share the same
+    canonicalisation. Catches future drift where one is normalised but
+    the other isn't.
+    """
+    model_dir = tmp_path / "synthetic_model"
+    out_dir = tmp_path / "out"
+    _write_synthetic_gemma4_model(
+        model_dir, include_stacked_experts=True, num_experts=4
+    )
+
+    full_convert(
+        model_id=str(model_dir),
+        adapter_name="gemma4",
+        output_dir=str(out_dir),
+        threshold=0.7,
+        verbose=False,
+    )
+
+    entries = _read_manifest(out_dir / "model.tern-model")
+    stacked_entries = [e for e in entries if e.get("stacked_parent")]
+
+    # Every stacked entry's name AND stacked_parent must be canonical
+    # (no ``language_model.`` prefix — Gemma4Adapter strips it).
+    for entry in stacked_entries:
+        assert "language_model." not in entry["name"], (
+            f"Slice name not normalised: {entry['name']}"
+        )
+        assert "language_model." not in entry["stacked_parent"], (
+            f"stacked_parent not normalised: {entry['stacked_parent']}"
+        )
+        # And the slice name shares the parent's prefix (after normalisation).
+        # Slice: model.layers.0.experts.K.gate_up_proj.weight
+        # Parent: model.layers.0.experts.gate_up_proj
+        # Strip the index + projection + .weight suffix off the slice name:
+        # the result up to and including ".experts." matches parent up to ".experts."
+        parent_prefix = entry["stacked_parent"].rsplit(".", 1)[0]  # drops "gate_up_proj"
+        assert entry["name"].startswith(parent_prefix + "."), (
+            f"Slice name '{entry['name']}' doesn't share parent prefix "
+            f"'{parent_prefix}'"
+        )

--- a/tests/test_gemma4_adapter_stacked.py
+++ b/tests/test_gemma4_adapter_stacked.py
@@ -1,0 +1,174 @@
+"""
+Tests for Gemma4Adapter stacked-experts expansion + expert_idx wiring.
+
+Session 3 per-expert slicing rework adds:
+- ``Gemma4Adapter.expand_stacked`` — fans stacked MoE expert tensors
+  (``experts.gate_up_proj`` / ``experts.down_proj``) out into per-expert
+  StackedSlice records along axis 0.
+- ``expert_pattern`` declared in ``info()`` so the inherited
+  ``_extract_expert_idx`` helper populates ``WeightClassification.expert_idx``
+  from synthesised per-expert names.
+
+Copyright (c) 2025–2026 Gamma Seeds Pte Ltd. All rights reserved.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from terncore.adapters.base import StackedSlice
+from terncore.adapters.gemma4 import Gemma4Adapter
+
+
+# ── expand_stacked: stacked-pattern recognition ─────────────────────
+
+
+def test_expand_stacked_recognises_experts_gate_up_proj():
+    """Parent ``experts.gate_up_proj`` fans out into 128 per-expert slices."""
+    adapter = Gemma4Adapter()
+    parent = "model.language_model.layers.0.experts.gate_up_proj"
+    plan = adapter.expand_stacked(parent, [128, 1408, 2816])
+
+    assert plan is not None
+    assert len(plan) == 128
+    assert all(isinstance(s, StackedSlice) for s in plan)
+
+    first = plan[0]
+    assert first.synthesised_name == (
+        "model.language_model.layers.0.experts.0.gate_up_proj.weight"
+    )
+    assert first.slice_axis == 0
+    assert first.slice_index == 0
+    assert first.expert_idx == 0
+
+    last = plan[-1]
+    assert last.synthesised_name == (
+        "model.language_model.layers.0.experts.127.gate_up_proj.weight"
+    )
+    assert last.slice_index == 127
+    assert last.expert_idx == 127
+
+
+def test_expand_stacked_recognises_experts_down_proj():
+    """Parent ``experts.down_proj`` fans out with the right projection token."""
+    adapter = Gemma4Adapter()
+    parent = "model.language_model.layers.7.experts.down_proj"
+    plan = adapter.expand_stacked(parent, [128, 2816, 704])
+
+    assert plan is not None
+    assert len(plan) == 128
+    assert plan[5].synthesised_name == (
+        "model.language_model.layers.7.experts.5.down_proj.weight"
+    )
+    assert plan[5].expert_idx == 5
+
+
+# ── expand_stacked: non-stacked patterns return None ────────────────
+
+
+def test_expand_stacked_returns_none_for_dense_mlp():
+    adapter = Gemma4Adapter()
+    name = "model.language_model.layers.0.mlp.gate_proj.weight"
+    assert adapter.expand_stacked(name, [2816, 2112]) is None
+
+
+def test_expand_stacked_returns_none_for_attention():
+    adapter = Gemma4Adapter()
+    name = "model.language_model.layers.0.self_attn.q_proj.weight"
+    assert adapter.expand_stacked(name, [4096, 2816]) is None
+
+
+def test_expand_stacked_returns_none_for_router_proj():
+    """``router.proj.weight`` is 2-D with leading 128 dim — must not expand.
+
+    The leading 128 matches num_experts but the name lacks the ``experts.``
+    substring, so the stacked-experts regex correctly declines.
+    """
+    adapter = Gemma4Adapter()
+    name = "model.language_model.layers.0.router.proj.weight"
+    assert adapter.expand_stacked(name, [128, 2816]) is None
+
+
+def test_expand_stacked_does_not_re_expand_synthesised_names():
+    """Synthesised per-expert names must NOT trigger re-expansion.
+
+    Exercises the end-anchor ``$`` asymmetry in ``_STACKED_EXPERTS_RE``.
+    A synthesised name carries an expert index plus trailing ``.weight``
+    and so must not match the parent-only regex.
+    """
+    adapter = Gemma4Adapter()
+    synthesised = "model.language_model.layers.0.experts.5.gate_up_proj.weight"
+    assert adapter.expand_stacked(synthesised, [1408, 2816]) is None
+
+
+# ── expand_stacked: halt-and-surface guard on wrong ndim ────────────
+
+
+def test_expand_stacked_raises_on_wrong_ndim():
+    """Pattern matched but shape isn't 3-D → ValueError naming the input."""
+    adapter = Gemma4Adapter()
+    name = "model.language_model.layers.0.experts.gate_up_proj"
+    with pytest.raises(ValueError) as exc_info:
+        adapter.expand_stacked(name, [1408, 2816])
+    msg = str(exc_info.value)
+    assert "experts.gate_up_proj" in msg
+    assert "[1408, 2816]" in msg or "shape" in msg.lower()
+
+
+# ── classify_weight: expert_idx wiring ──────────────────────────────
+
+
+def test_synthesised_name_classifies_with_expert_idx():
+    """Synthesised per-expert names get ``expert_idx`` populated."""
+    adapter = Gemma4Adapter()
+    name = "model.language_model.layers.0.experts.5.gate_up_proj.weight"
+    cls = adapter.classify_weight(name, [1408, 2816])
+    assert cls.category == "ternary_eligible"
+    assert cls.expert_idx == 5
+
+
+@pytest.mark.parametrize(
+    "name, shape, expected_category",
+    [
+        # Rule 5 — dense MLP, ternary_eligible
+        ("model.language_model.layers.0.mlp.gate_proj.weight", [2816, 2112], "ternary_eligible"),
+        # Rule 5 — attention, ternary_eligible
+        ("model.language_model.layers.0.self_attn.q_proj.weight", [4096, 2816], "ternary_eligible"),
+        # Rule 3 — norm, fp16_retain
+        ("model.language_model.layers.0.input_layernorm.weight", [2816], "fp16_retain"),
+        # Rule 3 — embed, fp16_retain
+        ("model.language_model.embed_tokens.weight", [262144, 2816], "fp16_retain"),
+        # Rule 1 — vision encoder, fp16_retain
+        ("model.vision_tower.encoder.layer.0.attention.q.weight", [1024, 1024], "fp16_retain"),
+    ],
+)
+def test_classify_weight_expert_idx_none_for_non_expert_names(
+    name, shape, expected_category,
+):
+    """Non-expert names get ``expert_idx=None`` across every classify return path.
+
+    Covers Rules 1, 3, and 5 (vision, protected pattern, ternary_eligible).
+    The wiring change touched all 5 return paths; this parametrise hits each.
+    """
+    adapter = Gemma4Adapter()
+    cls = adapter.classify_weight(name, shape)
+    assert cls.category == expected_category
+    assert cls.expert_idx is None
+
+
+# ── name uniqueness ─────────────────────────────────────────────────
+
+
+def test_expand_stacked_synthesised_names_are_unique():
+    """All 128 synthesised names for a parent must be distinct.
+
+    Catches off-by-one or template-string regressions in the
+    name-construction logic.
+    """
+    adapter = Gemma4Adapter()
+    parent = "model.language_model.layers.0.experts.gate_up_proj"
+    plan = adapter.expand_stacked(parent, [128, 1408, 2816])
+    names = [s.synthesised_name for s in plan]
+    assert len(set(names)) == 128
+    indices = [s.slice_index for s in plan]
+    assert sorted(indices) == list(range(128))

--- a/tests/test_tern_model_restacking.py
+++ b/tests/test_tern_model_restacking.py
@@ -1,0 +1,353 @@
+"""
+Reader-side tests for stacked-tensor restacking in
+``TernModelReader.reconstruct_all``.
+
+Session 3 per-expert slicing rework adds an in-flight per-parent
+accumulation pattern: when a manifest entry carries ``stacked_parent``
+metadata, slices are gathered until the per-parent count reaches
+``stack_total`` then restacked via ``torch.stack`` and emitted under
+the parent name. Three validation checks fire incrementally per parent
+(axes/totals consistency, slice count match, contiguous indices).
+
+These tests bypass ``convert.py:full_convert`` and exercise the reader
+directly via ``TernModelWriter`` calls — failures here localise to the
+reader's restacking logic without integration noise.
+
+Copyright (c) 2025–2026 Gamma Seeds Pte Ltd. All rights reserved.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+import torch
+
+from terncore.sparse import unpack_ternary_weights
+from terncore.tern_model import TernModelReader, TernModelWriter
+
+
+# ── Helpers ─────────────────────────────────────────────────────────
+
+
+def _write_temp_manifest(writer: TernModelWriter) -> Path:
+    """Write a manifest to a NamedTemporaryFile and return its Path.
+
+    Caller is responsible for ``os.unlink(path)`` after read.
+    """
+    with tempfile.NamedTemporaryFile(suffix=".tern-model", delete=False) as f:
+        path = Path(f.name)
+    writer.write(path)
+    return path
+
+
+def _add_stacked_slice(
+    writer: TernModelWriter,
+    parent: str,
+    slice_idx: int,
+    stack_total: int,
+    tensor: torch.Tensor,
+    *,
+    stack_axis: int = 0,
+    threshold: float = 0.7,
+) -> None:
+    """Pack a slice and add it under the synthesised per-expert name."""
+    packed, alpha, bitmap, sparsity = TernModelWriter.pack_ternary(
+        tensor, threshold
+    )
+    slice_name = parent.replace(
+        ".gate_up_proj", f".{slice_idx}.gate_up_proj"
+    ) + ".weight"
+    writer.add_ternary_layer(
+        name=slice_name,
+        packed_weights=packed,
+        alpha=alpha,
+        shape=list(tensor.shape),
+        sparsity_bitmap=bitmap,
+        threshold=threshold,
+        sparsity=sparsity,
+        stacked_parent=parent,
+        stack_axis=stack_axis,
+        stack_index=slice_idx,
+        stack_total=stack_total,
+    )
+
+
+# ── Round-trip + ordering ───────────────────────────────────────────
+
+
+def test_restacking_round_trip_preserves_slice_content_and_order():
+    """Each slice K from the original ends up at restacked[K] with the
+    quantised content preserved exactly (bitwise equal to direct
+    dequantisation of the same packed bytes)."""
+    torch.manual_seed(42)
+    parent = "model.layers.0.experts.gate_up_proj"
+    NUM = 4
+    slices_orig = [torch.randn(8, 16) for _ in range(NUM)]
+
+    # Capture the per-slice dequantised reference outside the writer
+    # loop so we can compare bitwise against the restacked tensor.
+    dequant_refs = []
+    writer = TernModelWriter()
+    for k, slice_t in enumerate(slices_orig):
+        packed, alpha, bitmap, sparsity = TernModelWriter.pack_ternary(slice_t, 0.7)
+        # Reference dequantisation via the same packing path
+        ternary_tensor = unpack_ternary_weights(
+            torch.frombuffer(bytearray(packed), dtype=torch.uint8),
+            torch.Size(slice_t.shape),
+        )
+        dequant_refs.append(ternary_tensor.float() * alpha)
+        writer.add_ternary_layer(
+            name=f"model.layers.0.experts.{k}.gate_up_proj.weight",
+            packed_weights=packed,
+            alpha=alpha,
+            shape=[8, 16],
+            sparsity_bitmap=bitmap,
+            threshold=0.7,
+            sparsity=sparsity,
+            stacked_parent=parent,
+            stack_axis=0,
+            stack_index=k,
+            stack_total=NUM,
+        )
+
+    path = _write_temp_manifest(writer)
+    try:
+        state_dict = TernModelReader(str(path)).reconstruct_all()
+    finally:
+        os.unlink(path)
+
+    assert parent in state_dict
+    restacked = state_dict[parent]
+    assert restacked.shape == torch.Size([NUM, 8, 16])
+
+    for k in range(NUM):
+        assert torch.equal(restacked[k], dequant_refs[k]), (
+            f"Slice {k} content not preserved in restack — slice ended up "
+            f"at wrong index or restacking introduced distortion."
+        )
+
+
+# ── Backwards compatibility ─────────────────────────────────────────
+
+
+def test_reconstruct_all_unchanged_for_pre_rework_manifest():
+    """Manifest with no stacking metadata behaves identically to pre-rework.
+
+    Verifies the rework added zero behaviour change for manifests written
+    without stacking kwargs (i.e., the entire installed-base of pre-Session-3
+    .tern-model artefacts).
+    """
+    torch.manual_seed(7)
+    writer = TernModelWriter()
+    names = [
+        "model.layers.0.self_attn.q_proj.weight",
+        "model.layers.0.mlp.gate_proj.weight",
+        "model.layers.0.input_layernorm.weight",  # production-suffix path
+    ]
+    for name in names:
+        weights = torch.randn(8, 16) if not name.endswith("layernorm.weight") else torch.randn(16)
+        if weights.ndim == 1:
+            writer.add_layer(name=name, weights=weights, dtype="float16")
+        else:
+            packed, alpha, bitmap, sparsity = TernModelWriter.pack_ternary(weights, 0.7)
+            writer.add_ternary_layer(
+                name=name,
+                packed_weights=packed,
+                alpha=alpha,
+                shape=list(weights.shape),
+                sparsity_bitmap=bitmap,
+                threshold=0.7,
+                sparsity=sparsity,
+            )
+
+    path = _write_temp_manifest(writer)
+    try:
+        state_dict = TernModelReader(str(path)).reconstruct_all()
+    finally:
+        os.unlink(path)
+
+    # Production-suffix names appear as-is. No new keys, no parent grouping.
+    expected_keys = set(names)
+    assert set(state_dict.keys()) == expected_keys, (
+        f"Pre-rework manifest produced unexpected keys: "
+        f"{set(state_dict.keys()) ^ expected_keys}"
+    )
+
+
+# ── Validation failure modes ────────────────────────────────────────
+
+
+def test_reconstruct_all_raises_on_incomplete_group():
+    """Truncated manifest: 2 of 4 slices written → end-of-manifest leftover guard."""
+    torch.manual_seed(1)
+    parent = "model.layers.0.experts.gate_up_proj"
+    writer = TernModelWriter()
+    for k in range(2):  # only 2 of 4 slices written
+        _add_stacked_slice(writer, parent, k, stack_total=4, tensor=torch.randn(8, 16))
+
+    path = _write_temp_manifest(writer)
+    try:
+        with pytest.raises(ValueError) as exc_info:
+            TernModelReader(str(path)).reconstruct_all()
+    finally:
+        os.unlink(path)
+    msg = str(exc_info.value)
+    assert parent in msg
+    assert "2/4" in msg
+
+
+def test_reconstruct_all_raises_on_inconsistent_axes():
+    """Slice index 2 declares a different stack_axis than its siblings."""
+    torch.manual_seed(2)
+    parent = "model.layers.0.experts.gate_up_proj"
+    writer = TernModelWriter()
+    for k in range(4):
+        # Slice 2 declares axis=1; rest declare axis=0
+        axis = 1 if k == 2 else 0
+        _add_stacked_slice(
+            writer, parent, k, stack_total=4,
+            tensor=torch.randn(8, 16), stack_axis=axis,
+        )
+
+    path = _write_temp_manifest(writer)
+    try:
+        with pytest.raises(ValueError) as exc_info:
+            TernModelReader(str(path)).reconstruct_all()
+    finally:
+        os.unlink(path)
+    msg = str(exc_info.value)
+    assert parent in msg
+    assert "axes" in msg.lower()
+
+
+def test_reconstruct_all_raises_on_inconsistent_totals():
+    """Slice index 3 declares a different stack_total than its siblings."""
+    torch.manual_seed(3)
+    parent = "model.layers.0.experts.gate_up_proj"
+    writer = TernModelWriter()
+    for k in range(4):
+        # Slice 3 claims total=8, rest claim total=4
+        total = 8 if k == 3 else 4
+        _add_stacked_slice(
+            writer, parent, k, stack_total=total, tensor=torch.randn(8, 16),
+        )
+
+    path = _write_temp_manifest(writer)
+    try:
+        with pytest.raises(ValueError) as exc_info:
+            TernModelReader(str(path)).reconstruct_all()
+    finally:
+        os.unlink(path)
+    msg = str(exc_info.value)
+    assert parent in msg
+    assert "total" in msg.lower()
+
+
+@pytest.mark.parametrize(
+    "indices, case_label",
+    [
+        ([0, 1, 3, 4], "gap"),         # missing index 2
+        ([0, 1, 1, 2], "duplicate"),   # index 1 appears twice
+    ],
+)
+def test_reconstruct_all_raises_on_invalid_indices(indices, case_label):
+    """Both gap and duplicate index patterns trigger the contiguity check."""
+    torch.manual_seed(4)
+    parent = "model.layers.0.experts.gate_up_proj"
+    writer = TernModelWriter()
+    for k in indices:
+        _add_stacked_slice(
+            writer, parent, k, stack_total=4, tensor=torch.randn(8, 16),
+        )
+
+    path = _write_temp_manifest(writer)
+    try:
+        with pytest.raises(ValueError) as exc_info:
+            TernModelReader(str(path)).reconstruct_all()
+    finally:
+        os.unlink(path)
+    msg = str(exc_info.value)
+    assert parent in msg, f"[{case_label}] parent not in error message"
+    # Either "non-contiguous" or "expected" should appear in the index-error message
+    assert ("non-contiguous" in msg or "expected" in msg.lower()), (
+        f"[{case_label}] error message doesn't reference index validation: {msg}"
+    )
+
+
+# ── Multi-parent independence ───────────────────────────────────────
+
+
+def test_reconstruct_all_handles_multiple_independent_stacks():
+    """Two parents interleaved in manifest order both restack correctly.
+
+    Bounded-memory property is verified-by-design: the per-parent
+    accumulation dict frees each parent's slice list immediately on
+    count match. Explicit memory profiling lives in integration tests
+    if needed; this test confirms the per-parent accumulation tracks
+    parents independently and emits both under their canonical keys.
+    """
+    torch.manual_seed(5)
+    parent_a = "model.layers.0.experts.gate_up_proj"
+    parent_b = "model.layers.1.experts.gate_up_proj"
+    NUM = 4
+    a_slices = [torch.randn(8, 16) for _ in range(NUM)]
+    b_slices = [torch.randn(8, 16) for _ in range(NUM)]
+
+    writer = TernModelWriter()
+    # Interleave: A0, B0, A1, B1, A2, B2, A3, B3
+    for k in range(NUM):
+        _add_stacked_slice(writer, parent_a, k, NUM, a_slices[k])
+        _add_stacked_slice(writer, parent_b, k, NUM, b_slices[k])
+
+    path = _write_temp_manifest(writer)
+    try:
+        state_dict = TernModelReader(str(path)).reconstruct_all()
+    finally:
+        os.unlink(path)
+
+    assert parent_a in state_dict
+    assert parent_b in state_dict
+    assert state_dict[parent_a].shape == torch.Size([NUM, 8, 16])
+    assert state_dict[parent_b].shape == torch.Size([NUM, 8, 16])
+    # And the two restacked tensors are distinct (different content)
+    assert not torch.equal(state_dict[parent_a], state_dict[parent_b])
+
+
+# ── Edge case: writer emits more slices than stack_total declares ───
+
+
+def test_reconstruct_all_raises_on_duplicate_parent_emission():
+    """Writer accidentally emits a parent's slices more than once.
+
+    The 4th slice triggers count match → restacks and frees the group.
+    The 5th slice re-creates the group with count=1, never reaches 4
+    again, end-of-manifest leftover guard fires reporting 1/4. This
+    documents expected behaviour for a writer-side bug; production
+    convert.py iterates each safetensors key exactly once so this case
+    cannot arise via the standard write path, but the test pins the
+    failure mode for diagnostic clarity if it ever does.
+    """
+    torch.manual_seed(6)
+    parent = "model.layers.0.experts.gate_up_proj"
+    writer = TernModelWriter()
+    # 5 slices for a 4-slice parent — the 5th re-opens the group post-restack.
+    for k in [0, 1, 2, 3, 0]:
+        _add_stacked_slice(
+            writer, parent, k, stack_total=4, tensor=torch.randn(8, 16),
+        )
+
+    path = _write_temp_manifest(writer)
+    try:
+        with pytest.raises(ValueError) as exc_info:
+            TernModelReader(str(path)).reconstruct_all()
+    finally:
+        os.unlink(path)
+    msg = str(exc_info.value)
+    assert parent in msg
+    assert "1/4" in msg, (
+        f"Expected leftover-guard message reporting 1/4 (5th slice reopened "
+        f"the group), got: {msg}"
+    )


### PR DESCRIPTION
## Summary

Per-expert quantisation for MoE stacked-expert tensors. Each expert weight in a Gemma 4 MoE block (e.g., the 128 experts in `experts.gate_up_proj`) now quantises independently with its own threshold, producing per-expert sparsity records in the .tern-model manifest. This enables direct measurement of the per-expert zero-state ratio distribution from manifest data — the IP claim hypothesis from `tern-core/CLAUDE.md`'s "Gemma 4 26B MoE — IP opportunity".

## Substantive rework

Pre-rework, MoE expert weights packed as a single 3-D safetensors entry per layer (e.g., `experts.gate_up_proj` shape `[128, 1408, 2816]`) flowed through `full_convert` as one Linear, producing one shared threshold and one aggregate sparsity number per layer. The IP claim — per-expert zero-state ratio distribution showing a meaningful right-shift vs dense layer weights — required per-expert measurement that the existing pipeline collapsed.

The rework introduces an adapter-side expansion contract:

- New `StackedSlice` dataclass + `ArchitectureAdapter.expand_stacked` base method (returns None for non-MoE adapters by default).
- `Gemma4Adapter` overrides `expand_stacked` to recognise the two stacked expert patterns and fan them out into per-expert `StackedSlice` records along axis 0 with synthesised names `…experts.K.<projection>.weight`.
- `convert.py:full_convert` calls `expand_stacked` during shape collection (replaces parent entries with per-slice entries in `weight_shapes`) and during the per-tensor processing loop (slices the loaded parent tensor, passes each slice through `pack_ternary` independently, emits per-slice ternary records with stacking metadata).
- `TernModelWriter.add_ternary_layer` accepts four optional keyword-only kwargs (`stacked_parent`, `stack_axis`, `stack_index`, `stack_total`) for recording per-slice records.
- `TernModelReader.reconstruct_all` accumulates slices in-flight per parent and restacks immediately when the per-parent count reaches `stack_total`, freeing the slice list before continuing iteration.

## Four findings during design

1. **Engineering paid forward partially**: Group A's adapter widening (`expert_idx` field) and StreamingConverter v0.5.0's per-tensor sparsity recording were structurally MoE-aware but not at the right granularity. The Session 2 audit had concluded "no code change needed for MoE" — correct at the file level but blind to the safetensors-layout granularity where each layer's 128 experts pack as a single 3-D entry.
2. **Methodology refinement banked**: yesterday's audit didn't extend to actual safetensors layouts. Updated `pattern_engineering_paying_forward_v1` memory to require dual-axis verification (code + on-disk artefact) before any "no-code-needed" conclusion ships.
3. **OOM risk caught pre-implementation**: the initial design surface for `reconstruct_all` proposed deferred restack — accumulate all slices then torch.stack at end. Memory analysis caught that this would peak at ~120 GB for a 26B-A4B reconstruction (7,680 slices × ~16 MB each held simultaneously). Halted, surfaced, switched to incremental per-parent restack (~2 GB peak per in-flight parent — within the M4 Pro 64 GB envelope). The writer-side contiguity contract (each parent's slices written contiguously) is what makes this bounded.
4. **Baseline path correction**: the Gemopus-4-E4B baseline path turned out to be a directory containing `model.tern-model`, not a file directly. First test run surfaced `IsADirectoryError`; corrected the path constant in `tests/test_e4b_regression.py`.

## Test coverage

- **33 new tests** across 4 files (adapter, convert, tern_model restacking, E4B regression). All passing.
- **1 existing test updated**: `tests/test_adapters_schema_widening.py` parametrise list reduced from `[Llama, Gemma3, Gemma4]` to `[Llama, Gemma3]` since Gemma4Adapter now legitimately declares `expert_pattern`.
- **Full suite**: 435 passed, 3 skipped, 0 failures (excludes slow tests).
- **Empirical expansion math** verified against the on-disk 26B-A4B safetensors index: 60 stacked parents → 7,680 per-slice entries; total post-expansion 8,633 entries (vs 1,013 pre-expansion).

## Forward path (downstream of this PR)

- Session 3 Step 4: dual-compression run (Google base + Jackrong fine-tune) produces real per-expert sparsity data in two manifests.
- Session 4: per-expert tolerance analysis script (`benchmarks/analyse_per_expert_tolerance.py`, landed in PR #12) runs against both manifests, produces the IP measurement output (per-expert vs dense distribution comparison + Llama-70B cross-model reference).

## Configurational fidelity assertion deferment

The 26B-A4B band assertion (`7800 ≤ ternary_layers ≤ 7950`) lands at the dual-compression invocation site (Step 4 of Session 3 plan, downstream of this PR), not in this rework — that's where the architectural ground truth formula belongs per the Q5 design from the orientation memory. The existing `< 350` E4B guard in `benchmarks/bench_gemopus_phase2.py` is untouched (verified safe by tests 1-3 in `test_e4b_regression.py` and the synthetic dense-only regression test in `test_full_convert_per_expert.py`).

## Backwards compatibility

Pre-rework manifests have no `stacked_parent` field on any entry → reader's new branch is skipped entirely → existing test/production-convention paths are byte-for-byte equivalent. Verified by:

- `test_reconstruct_all_unchanged_for_pre_rework_manifest` (synthetic)
- `test_baseline_manifest_reads_cleanly` + `test_baseline_has_no_stacking_metadata` + `test_baseline_reconstruct_all_succeeds` (real Gemopus-4-E4B artefact)

## Backlog items banked

- `full_attention v_proj` quirk on gemma4 26B-A4B (count formula already incorporates the asymmetry; investigation deferred for thoroughness)
- `dry_run_convert` doesn't model stacked-tensor expansion (informational only; full_convert handles it correctly)