### PR TITLE
Session Thursday: Phi3Adapter + Qwen3MoeAdapter for cross-architecture compression

### DIFF
--- a/benchmarks/analyse_per_expert_tolerance.py
+++ b/benchmarks/analyse_per_expert_tolerance.py
@@ -55,6 +55,24 @@ MODEL_GROUP_PATTERNS: dict[str, dict[str, list[str]]] = {
                         r"\.mlp\.down_proj\.weight$"],
         "attention":   [r"\.self_attn\.[qkvo]_proj\.weight$"],
     },
+    "phi3_dense": {
+        "expert_ffn":  [],  # Phi-3 / Phi-4 dense; no experts
+        # Phi-4 uses fused gate+up (gate_up_proj) + separate down_proj
+        "dense_ffn":   [r"\.mlp\.gate_up_proj\.weight$",
+                        r"\.mlp\.down_proj\.weight$"],
+        # Phi-4 uses fused QKV (qkv_proj) + separate o_proj
+        "attention":   [r"\.self_attn\.qkv_proj\.weight$",
+                        r"\.self_attn\.o_proj\.weight$"],
+    },
+    "qwen3_moe": {
+        # Qwen3 stores per-expert weights as separate gate/up/down
+        # 2-D indexed tensors (no fused gate_up like Gemma 4).
+        "expert_ffn":  [r"\.mlp\.experts\.\d+\.gate_proj\.weight$",
+                        r"\.mlp\.experts\.\d+\.up_proj\.weight$",
+                        r"\.mlp\.experts\.\d+\.down_proj\.weight$"],
+        "dense_ffn":   [],  # Qwen3 has NO parallel dense MLP (pure MoE FFN)
+        "attention":   [r"\.self_attn\.[qkvo]_proj\.weight$"],
+    },
     # Extend for new architectures by mirroring the gemma4_moe shape.
 }
 

--- a/benchmarks/run_compression_gemma4_31b.py
+++ b/benchmarks/run_compression_gemma4_31b.py
@@ -1,0 +1,180 @@
+"""
+Gemma 4 31B dense compression — Thursday 2026-05-07 single-model run.
+
+Uses existing Gemma4Adapter directly (verified during pre-flight Thursday AM:
+31B is dense, num_experts=None, enable_moe_block=False, no per-expert
+slicing needed). Configurational fidelity assertion derived from HF
+text_config per Q5 design — same architectural-ground-truth pattern as
+the dual-compression script for 26B-A4B, simplified for the dense case.
+
+Single-model template form: future single-model compressions (Phi-4
+dense, Qwen3-30B-A3B MoE, etc.) can copy and modify the constants
+section + compute function for their architecture.
+
+Usage:
+    python benchmarks/run_compression_gemma4_31b.py
+
+Wall-clock estimate: ~45-60 min on M4 Pro (60 layers vs 30 for 26B-A4B,
+roughly 2x tensor count post-classification at 410 + protected; offset by
+no per-expert slicing overhead).
+
+Copyright (c) 2026 Gamma Seeds Pte Ltd. All rights reserved.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+from terncore.convert import full_convert
+from terncore.tern_model import TernModelReader
+
+
+# ── Sprint constants ────────────────────────────────────────────────
+
+SOURCE_HF_ID = "mlx-community/gemma-4-31b-it-bf16"
+OUTPUT_DIR = Path(
+    "/Volumes/Syn Archive/models/compressed/gemma4-31b/"
+    "gemma4_31b_ternary_v0.1.0.tern-model"
+)
+THRESHOLD = 0.7
+TOLERANCE = 65  # ±tolerance band; matches dual-compression-script convention
+
+
+# ── Architectural ground truth ──────────────────────────────────────
+
+
+def compute_expected_ternary_count(text_config: dict) -> int:
+    """Architectural ground truth for dense Gemma 4 ternary-eligible count.
+
+    Per-layer breakdown for dense Gemma 4:
+    - 3 dense MLP weights (gate_proj, up_proj, down_proj)
+    - 4 attention weights for sliding_attention (q, k, v, o)
+      OR 3 attention weights for full_attention (q, k, o — no v_proj
+      per ``docs/backlog.md`` "Known architecture quirk: full_attention
+      v_proj absence", confirmed for 31B in pre-flight inspection)
+
+    Generalises across Gemma 4 dense variants by reading ``layer_types``
+    from text_config. For 31B (60 layers: 50 sliding + 10 full):
+    50*7 + 10*6 = 410.
+    """
+    layer_types = text_config["layer_types"]
+    sliding = layer_types.count("sliding_attention")
+    full = layer_types.count("full_attention")
+
+    dense_mlp = 3
+    sliding_per_layer = dense_mlp + 4
+    full_per_layer = dense_mlp + 3
+
+    return sliding * sliding_per_layer + full * full_per_layer
+
+
+def assert_configurational_fidelity(
+    report: dict, expected: int, tolerance: int = TOLERANCE,
+) -> None:
+    """Hard guard on ``ternary_layers`` count vs HF-derived expectation."""
+    actual = report["ternary_layers"]
+    if not (expected - tolerance <= actual <= expected + tolerance):
+        raise ValueError(
+            f"Configurational fidelity violation: expected ~{expected} "
+            f"(±{tolerance}), got {actual}. Full report: {report}"
+        )
+
+
+def load_text_config_via_hf(hf_id: str) -> dict:
+    """Resolve text_config via huggingface_hub (config-only, cache-aware)."""
+    from huggingface_hub import snapshot_download
+    config_dir = snapshot_download(hf_id, allow_patterns=["config.json"])
+    with open(Path(config_dir) / "config.json") as f:
+        cfg = json.load(f)
+    return cfg.get("text_config", cfg)
+
+
+def write_run_summary(
+    report: dict,
+    expected: int,
+    output_dir: Path,
+    label: str,
+    started_at: str,
+    finished_at: str,
+    wall_clock_seconds: float,
+) -> None:
+    summary = {
+        "label": label,
+        "input_source": report.get("model_id"),
+        "output_path": report.get("output_path"),
+        "threshold": report.get("threshold"),
+        "ternary_layers": report["ternary_layers"],
+        "ternary_params": report["ternary_params"],
+        "expected_ternary_count": expected,
+        "tolerance_band": [expected - TOLERANCE, expected + TOLERANCE],
+        "fidelity_pass": True,
+        "fp16_layers": report["fp16_layers"],
+        "fp16_params": report["fp16_params"],
+        "int4_layers": report["int4_layers"],
+        "int4_params": report["int4_params"],
+        "compression_vs_fp16": report.get("compression_vs_fp16"),
+        "file_size_bytes": report.get("file_size_bytes"),
+        "wall_clock_seconds": round(wall_clock_seconds, 2),
+        "started_at": started_at,
+        "finished_at": finished_at,
+    }
+    summary_path = output_dir / "run_summary.json"
+    summary_path.write_text(json.dumps(summary, indent=2) + "\n")
+    print(f"[ok] run_summary written: {summary_path}", flush=True)
+
+
+# ── Main ────────────────────────────────────────────────────────────
+
+
+def main() -> int:
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    started_at = datetime.now(timezone.utc).isoformat()
+    t_start = time.perf_counter()
+    print(
+        f"\n[{started_at}] Run starting: gemma4_31b_dense\n"
+        f"  source: {SOURCE_HF_ID}\n"
+        f"  output: {OUTPUT_DIR}",
+        flush=True,
+    )
+
+    text_config = load_text_config_via_hf(SOURCE_HF_ID)
+    expected = compute_expected_ternary_count(text_config)
+    print(
+        f"  Expected ternary count: ~{expected} "
+        f"(±{TOLERANCE}; layer_types: "
+        f"{text_config['layer_types'].count('sliding_attention')} sliding + "
+        f"{text_config['layer_types'].count('full_attention')} full)",
+        flush=True,
+    )
+
+    report = full_convert(
+        model_id=SOURCE_HF_ID,
+        adapter_name="gemma4",
+        output_dir=str(OUTPUT_DIR),
+        threshold=THRESHOLD,
+        verbose=True,
+    )
+
+    wall_clock = time.perf_counter() - t_start
+    finished_at = datetime.now(timezone.utc).isoformat()
+    assert_configurational_fidelity(report, expected)
+    write_run_summary(
+        report, expected, OUTPUT_DIR, "gemma4_31b_dense",
+        started_at, finished_at, wall_clock,
+    )
+    print(
+        f"\n[{finished_at}] Run complete: gemma4_31b_dense "
+        f"({wall_clock / 60:.1f} min wall)\n"
+        f"  ternary_layers: {report['ternary_layers']} "
+        f"(expected ~{expected}, ±{TOLERANCE}) — PASS",
+        flush=True,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/terncore/adapters/__init__.py
+++ b/src/terncore/adapters/__init__.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 
 _REGISTRY: dict[str, type["ArchitectureAdapter"]] = {}
 
-_KNOWN_ADAPTERS = ["llama", "gemma3", "gemma4"]
+_KNOWN_ADAPTERS = ["llama", "gemma3", "gemma4", "phi3", "qwen3_moe"]
 
 
 def register(name: str):

--- a/src/terncore/adapters/phi3.py
+++ b/src/terncore/adapters/phi3.py
@@ -1,0 +1,131 @@
+"""
+Phi-3 / Phi-4 architecture adapter for tern-core conversion pipeline.
+
+Maps Microsoft Phi-3 / Phi-4 (``Phi3ForCausalLM``) HuggingFace weight
+names to tern-core's internal weight schema. Note that Phi-4 retains
+the Phi3 architecture class name; the adapter covers both generations.
+
+Phi-3/4 quirks vs Llama:
+- Fused QKV projection: ``self_attn.qkv_proj.weight`` (single tensor
+  instead of separate q_proj/k_proj/v_proj)
+- Fused gate+up projection: ``mlp.gate_up_proj.weight`` (single tensor
+  instead of separate gate_proj/up_proj)
+- ``self_attn.o_proj.weight`` and ``mlp.down_proj.weight`` remain
+  separate as in Llama
+
+Fused-projection handling decision: treat as single tensors. Each
+fused tensor receives one threshold-derived ternary cutoff and one
+sparsity record. The per-component sparsity question (does Q have
+different sparsity than V? does gate vs up?) is deferred until
+cross-architecture analysis surfaces a per-component signal worth
+investigating; the fused-as-single approach matches Phi-4's actual
+forward-pass shape (one nn.Linear) and matches April 2026 prior
+production practice (LlamaAdapter route, 160 ternary entries on
+``microsoft/phi-4`` — verified).
+
+Classification rules mirror LlamaAdapter (proven on Phi-4 in prior
+compression); this adapter exists primarily to declare the
+architecture allow-list for ``validate_architecture`` per the
+post-Group-A allow-list discipline (description strings are
+aspirational, allow-lists are gates).
+
+Copyright (c) 2025–2026 Gamma Seeds Pte Ltd. All rights reserved.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+from terncore.adapters import register
+from terncore.adapters.base import (
+    AdapterInfo,
+    ArchitectureAdapter,
+    WeightClassification,
+)
+
+_BLOCK_PATTERN = re.compile(r"\.layers\.(\d+)\.")
+
+_PROJ_PRIORITY = [
+    "qkv_proj",       # fused Q/K/V — single tensor per layer
+    "o_proj",         # separate output projection
+    "gate_up_proj",   # fused gate+up — single tensor per layer
+    "down_proj",      # separate down projection
+]
+
+_ALWAYS_PROTECTED = (
+    "embed_tokens",
+    "lm_head",
+    "norm",
+    "layernorm",
+    "layer_norm",
+    "rmsnorm",
+    "classifier",
+)
+
+
+@register("phi3")
+class Phi3Adapter(ArchitectureAdapter):
+    """Architecture adapter for Phi3ForCausalLM (Phi-3 + Phi-4).
+
+    Weight classification (mirrors LlamaAdapter, validated on Phi-4 in
+    April 2026 production compression):
+    1. Embeddings, norms, LM head → FP16-retain.
+    2. 1-D weights (biases, scalars) → FP16-retain.
+    3. All 2-D weights in transformer blocks → ternary-eligible
+       (including fused qkv_proj and gate_up_proj as single tensors).
+    """
+
+    def info(self) -> AdapterInfo:
+        return AdapterInfo(
+            name="phi3",
+            architectures=["Phi3ForCausalLM"],
+            model_type="phi3",
+            description=(
+                "Microsoft Phi-3 / Phi-4 adapter — fused QKV + fused "
+                "gate_up projections treated as single ternary tensors. "
+                "Text-only."
+            ),
+            block_pattern=_BLOCK_PATTERN,
+            projection_priority=list(_PROJ_PRIORITY),
+            protection_patterns=list(_ALWAYS_PROTECTED),
+            multimodal=False,
+        )
+
+    def normalize_name(self, name: str) -> str:
+        return name
+
+    def classify_weight(
+        self,
+        name: str,
+        shape: Optional[list[int]] = None,
+    ) -> WeightClassification:
+        canonical = self.normalize_name(name)
+        name_lower = canonical.lower()
+
+        for pattern in _ALWAYS_PROTECTED:
+            if pattern in name_lower:
+                return WeightClassification(
+                    name=name,
+                    canonical_name=canonical,
+                    category="fp16_retain",
+                    reason=f"Protected pattern: '{pattern}'",
+                    component="language",
+                )
+
+        if shape is not None and len(shape) < 2:
+            return WeightClassification(
+                name=name,
+                canonical_name=canonical,
+                category="fp16_retain",
+                reason="1-D tensor (bias or scalar parameter)",
+                component="language",
+            )
+
+        return WeightClassification(
+            name=name,
+            canonical_name=canonical,
+            category="ternary_eligible",
+            reason="2-D weight in transformer block — eligible for ternary conversion",
+            component="language",
+        )

--- a/src/terncore/adapters/qwen3_moe.py
+++ b/src/terncore/adapters/qwen3_moe.py
@@ -1,0 +1,160 @@
+"""
+Qwen3 MoE architecture adapter for tern-core conversion pipeline.
+
+Maps Alibaba Qwen3 MoE (``Qwen3MoeForCausalLM``) HuggingFace weight
+names to tern-core's internal weight schema. Targets the
+Qwen3-30B-A3B variant (128 experts, top-k 8, ~3B active) and any
+future Qwen3MoE family members sharing the same architecture class.
+
+Qwen3MoE quirks vs Gemma 4 26B-A4B:
+- **Per-expert tensors are 2-D indexed in the safetensors index**
+  (``mlp.experts.K.gate_proj.weight`` for each K in 0..127), NOT
+  packed as 3-D stacked tensors like Gemma 4's
+  ``experts.gate_up_proj``. No ``expand_stacked`` logic needed —
+  per-expert sparsity falls out naturally during quantisation.
+- **No parallel dense MLP path.** Qwen3 has only the expert FFN
+  branch; Gemma 4 has both per-expert weights AND parallel dense
+  MLP per layer. Cross-architecture analysis must account for this
+  structural difference (cf. Thursday 2026-05-07 banked finding in
+  ``project_gemopus_26b_moe_compression_v1`` memory).
+- **Router weight is ``mlp.gate.weight``** (not ``router.*`` like
+  Gemma 4). Discriminating from expert gate projections
+  (``mlp.experts.K.gate_proj.weight``) requires the protected
+  substring ``"mlp.gate."`` with trailing period — the underscore
+  in ``gate_proj`` breaks the substring match. Without the trailing
+  period, expert gate weights would silently misclassify as
+  FP16-protected (cf. ``pattern_substring_pattern_discrimination_v1``).
+- **Separate gate/up/down per expert.** Gemma 4 fuses gate+up in
+  ``experts.gate_up_proj``; Qwen3 keeps them separate. Means more
+  per-layer entries (3 per expert instead of 2) but uniform
+  per-component sparsity measurement.
+
+Copyright (c) 2025–2026 Gamma Seeds Pte Ltd. All rights reserved.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+from terncore.adapters import register
+from terncore.adapters.base import (
+    AdapterInfo,
+    ArchitectureAdapter,
+    WeightClassification,
+)
+
+_BLOCK_PATTERN = re.compile(r"\.layers\.(\d+)\.")
+
+_PROJ_PRIORITY = [
+    "v_proj",
+    "k_proj",
+    "o_proj",
+    "q_proj",
+    "gate_proj",
+    "up_proj",
+    "down_proj",
+]
+
+# Protection patterns. The trailing period on ``"mlp.gate."`` is
+# load-bearing — it discriminates the router (``mlp.gate.weight``)
+# from expert gate projections (``mlp.experts.K.gate_proj.weight``)
+# via substring matching. Removing the trailing period would cause
+# all expert gate weights to silently misclassify as FP16-protected
+# (the underscore in ``gate_proj`` is what breaks the substring
+# match cleanly). Cf. ``pattern_substring_pattern_discrimination_v1``.
+_ALWAYS_PROTECTED = (
+    "embed_tokens",
+    "lm_head",
+    "norm",
+    "layernorm",
+    "layer_norm",
+    "rmsnorm",
+    "classifier",
+    "mlp.gate.",  # router weight; trailing period is load-bearing
+)
+
+# Expert index pattern. Matches the Qwen3 per-expert names produced
+# directly in the safetensors index (no synthesis needed — Qwen3
+# stores experts as 2-D indexed tensors). The inherited
+# ``_extract_expert_idx`` helper uses this to populate
+# ``WeightClassification.expert_idx`` from the matched name.
+_EXPERT_IDX_RE = re.compile(r"\.mlp\.experts\.(?P<expert_idx>\d+)\.")
+
+
+@register("qwen3_moe")
+class Qwen3MoeAdapter(ArchitectureAdapter):
+    """Architecture adapter for Qwen3MoeForCausalLM family.
+
+    Weight classification:
+    1. Embeddings, norms, LM head, **router** (``mlp.gate.weight``)
+       → FP16-retain.
+    2. 1-D weights (biases, scalars) → FP16-retain.
+    3. All 2-D weights in transformer blocks → ternary-eligible.
+       Per-expert weights (``mlp.experts.K.{gate,up,down}_proj.weight``)
+       receive their own per-tensor threshold during compression
+       (per-expert IP measurement granularity); the inherited
+       ``_extract_expert_idx`` populates ``expert_idx`` from the
+       matched index.
+    """
+
+    def info(self) -> AdapterInfo:
+        return AdapterInfo(
+            name="qwen3_moe",
+            architectures=["Qwen3MoeForCausalLM"],
+            model_type="qwen3_moe",
+            description=(
+                "Alibaba Qwen3 MoE adapter — per-expert 2-D indexed "
+                "tensors (no expand_stacked needed), router as "
+                "mlp.gate.weight discriminated from expert gate "
+                "projections via trailing-period substring match. "
+                "Pure MoE FFN (no parallel dense MLP path). Text-only."
+            ),
+            block_pattern=_BLOCK_PATTERN,
+            projection_priority=list(_PROJ_PRIORITY),
+            protection_patterns=list(_ALWAYS_PROTECTED),
+            multimodal=False,
+            expert_pattern=_EXPERT_IDX_RE,
+        )
+
+    def normalize_name(self, name: str) -> str:
+        return name
+
+    def classify_weight(
+        self,
+        name: str,
+        shape: Optional[list[int]] = None,
+    ) -> WeightClassification:
+        canonical = self.normalize_name(name)
+        name_lower = canonical.lower()
+        expert_idx = self._extract_expert_idx(name)
+
+        for pattern in _ALWAYS_PROTECTED:
+            if pattern in name_lower:
+                return WeightClassification(
+                    name=name,
+                    canonical_name=canonical,
+                    category="fp16_retain",
+                    reason=f"Protected pattern: '{pattern}'",
+                    component="language",
+                    expert_idx=expert_idx,
+                )
+
+        if shape is not None and len(shape) < 2:
+            return WeightClassification(
+                name=name,
+                canonical_name=canonical,
+                category="fp16_retain",
+                reason="1-D tensor (bias or scalar parameter)",
+                component="language",
+                expert_idx=expert_idx,
+            )
+
+        return WeightClassification(
+            name=name,
+            canonical_name=canonical,
+            category="ternary_eligible",
+            reason="2-D weight in transformer block — eligible for ternary conversion",
+            component="language",
+            expert_idx=expert_idx,
+        )

--- a/tests/test_adapters_registry.py
+++ b/tests/test_adapters_registry.py
@@ -32,14 +32,14 @@ def test_get_adapter_raises_on_unknown_name_case_insensitive():
         get_adapter("LLAMA_FAKE")
 
 
-@pytest.mark.parametrize("name", ["llama", "gemma3", "gemma4"])
+@pytest.mark.parametrize("name", ["llama", "gemma3", "gemma4", "phi3", "qwen3_moe"])
 def test_get_adapter_returns_instance_for_each_known_name(name):
     adapter = get_adapter(name)
     assert isinstance(adapter, ArchitectureAdapter)
     assert adapter.info().name == name
 
 
-@pytest.mark.parametrize("name", ["LLAMA", "Gemma3", "GEMMA4"])
+@pytest.mark.parametrize("name", ["LLAMA", "Gemma3", "GEMMA4", "PHI3", "Qwen3_MoE"])
 def test_get_adapter_accepts_mixed_case_known_names(name):
     adapter = get_adapter(name)
     assert isinstance(adapter, ArchitectureAdapter)
@@ -47,4 +47,4 @@ def test_get_adapter_accepts_mixed_case_known_names(name):
 
 
 def test_known_adapters_is_canonical_source():
-    assert set(_KNOWN_ADAPTERS) == {"llama", "gemma3", "gemma4"}
+    assert set(_KNOWN_ADAPTERS) == {"llama", "gemma3", "gemma4", "phi3", "qwen3_moe"}

--- a/tests/test_adapters_schema_widening.py
+++ b/tests/test_adapters_schema_widening.py
@@ -26,6 +26,7 @@ from terncore.adapters.base import (
 from terncore.adapters.gemma3 import Gemma3Adapter
 from terncore.adapters.gemma4 import Gemma4Adapter
 from terncore.adapters.llama import LlamaAdapter
+from terncore.adapters.phi3 import Phi3Adapter
 
 
 _BLOCK_PATTERN = re.compile(r"\.layers\.(\d+)\.")
@@ -180,11 +181,11 @@ def test_detect_attention_type_returns_full_when_pattern_misses():
 
 @pytest.mark.parametrize(
     "adapter_cls",
-    [LlamaAdapter, Gemma3Adapter],
+    [LlamaAdapter, Gemma3Adapter, Phi3Adapter],
 )
 def test_existing_adapters_have_none_for_new_info_fields(adapter_cls):
-    """Smoke positive: llama/gemma3 declare neither expert_pattern nor
-    attention_type_pattern. The Group A schema widening must be a
+    """Smoke positive: llama/gemma3/phi3 declare neither expert_pattern
+    nor attention_type_pattern. The Group A schema widening must be a
     pure-additive no-op for non-MoE, non-hybrid adapters.
 
     Gemma4Adapter was excluded from this list during the Session 3
@@ -193,6 +194,15 @@ def test_existing_adapters_have_none_for_new_info_fields(adapter_cls):
     can populate ``WeightClassification.expert_idx`` from synthesised
     per-expert names. That declaration is exercised by tests in
     ``test_gemma4_adapter_stacked.py``.
+
+    Qwen3MoeAdapter is similarly excluded — it declares
+    ``expert_pattern`` for Qwen3's per-expert 2-D indexed tensors
+    (no expand_stacked needed; declaration is exercised by tests in
+    ``test_qwen3_moe_adapter.py``).
+
+    Phi3Adapter is dense (Phi-3 / Phi-4 with fused QKV + fused gate_up
+    treated as single tensors); included in this list to confirm the
+    schema-widening invariant holds.
     """
     info = adapter_cls().info()
     assert info.expert_pattern is None

--- a/tests/test_phi3_adapter.py
+++ b/tests/test_phi3_adapter.py
@@ -1,0 +1,111 @@
+"""
+Tests for Phi3Adapter — Microsoft Phi-3 / Phi-4 architecture support.
+
+PR #16 cross-architecture sprint cluster (2026-05-07): Phi3Adapter
+declares the architecture allow-list for ``Phi3ForCausalLM`` and
+mirrors LlamaAdapter's classification logic, validated against
+April 2026 prior production compression of Phi-4 via the
+``--adapter llama`` route.
+
+Copyright (c) 2025–2026 Gamma Seeds Pte Ltd. All rights reserved.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from terncore.adapters.base import ArchitectureMismatch
+from terncore.adapters.phi3 import Phi3Adapter
+
+
+# ── Architecture allow-list ─────────────────────────────────────────
+
+
+def test_phi3_adapter_accepts_phi3forcausallm():
+    Phi3Adapter().validate_architecture("Phi3ForCausalLM")
+
+
+def test_phi3_adapter_rejects_other_architectures():
+    adapter = Phi3Adapter()
+    for arch in ("LlamaForCausalLM", "Gemma4ForConditionalGeneration",
+                 "Qwen3MoeForCausalLM", "MistralForCausalLM"):
+        with pytest.raises(ArchitectureMismatch):
+            adapter.validate_architecture(arch)
+
+
+# ── Fused-projection classification (the Phi quirk) ─────────────────
+
+
+def test_fused_qkv_proj_is_ternary_eligible():
+    """Phi's fused QKV is a single 2-D Linear weight; treat as one
+    ternary entity (single threshold, single sparsity record).
+    """
+    cls = Phi3Adapter().classify_weight(
+        "model.layers.0.self_attn.qkv_proj.weight",
+        shape=[15360, 5120],
+    )
+    assert cls.category == "ternary_eligible"
+
+
+def test_fused_gate_up_proj_is_ternary_eligible():
+    """Phi's fused gate+up is a single 2-D Linear weight; treat as one
+    ternary entity.
+    """
+    cls = Phi3Adapter().classify_weight(
+        "model.layers.0.mlp.gate_up_proj.weight",
+        shape=[35840, 5120],
+    )
+    assert cls.category == "ternary_eligible"
+
+
+def test_separate_o_proj_and_down_proj_are_ternary_eligible():
+    adapter = Phi3Adapter()
+    for name in (
+        "model.layers.0.self_attn.o_proj.weight",
+        "model.layers.0.mlp.down_proj.weight",
+    ):
+        cls = adapter.classify_weight(name, shape=[5120, 5120])
+        assert cls.category == "ternary_eligible", (
+            f"{name} should be ternary_eligible, got {cls.category}"
+        )
+
+
+# ── Standard protection rules ───────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "name, shape, expected",
+    [
+        ("model.layers.0.input_layernorm.weight", [5120], "fp16_retain"),
+        ("model.layers.0.post_attention_layernorm.weight", [5120], "fp16_retain"),
+        ("model.embed_tokens.weight", [100352, 5120], "fp16_retain"),
+        ("model.norm.weight", [5120], "fp16_retain"),
+        ("lm_head.weight", [100352, 5120], "fp16_retain"),
+    ],
+)
+def test_phi3_protected_patterns(name, shape, expected):
+    cls = Phi3Adapter().classify_weight(name, shape)
+    assert cls.category == expected
+
+
+def test_phi3_one_d_weight_is_protected():
+    """1-D tensors (biases, scalars) get FP16-retained even without
+    matching a protected substring."""
+    cls = Phi3Adapter().classify_weight(
+        "model.layers.0.something.bias",
+        shape=[5120],
+    )
+    assert cls.category == "fp16_retain"
+
+
+# ── No MoE, no expand_stacked ───────────────────────────────────────
+
+
+def test_phi3_expand_stacked_returns_none():
+    """Phi-4 is dense; expand_stacked is a no-op (inherited base default)."""
+    adapter = Phi3Adapter()
+    for name, shape in (
+        ("model.layers.0.self_attn.qkv_proj.weight", [15360, 5120]),
+        ("model.layers.0.mlp.gate_up_proj.weight", [35840, 5120]),
+    ):
+        assert adapter.expand_stacked(name, shape) is None

--- a/tests/test_qwen3_moe_adapter.py
+++ b/tests/test_qwen3_moe_adapter.py
@@ -1,0 +1,165 @@
+"""
+Tests for Qwen3MoeAdapter — Alibaba Qwen3 MoE architecture support.
+
+PR #16 cross-architecture sprint cluster (2026-05-07): Qwen3MoeAdapter
+handles per-expert 2-D indexed tensors directly (no expand_stacked
+needed since each expert is already its own safetensors entry), with
+the substantive quirk being the router/expert-gate discrimination
+via the trailing-period substring pattern ``"mlp.gate."`` (cf.
+``pattern_substring_pattern_discrimination_v1``).
+
+Copyright (c) 2025–2026 Gamma Seeds Pte Ltd. All rights reserved.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from terncore.adapters.base import ArchitectureMismatch
+from terncore.adapters.qwen3_moe import Qwen3MoeAdapter
+
+
+# ── Architecture allow-list ─────────────────────────────────────────
+
+
+def test_qwen3_moe_adapter_accepts_qwen3moeforcausallm():
+    Qwen3MoeAdapter().validate_architecture("Qwen3MoeForCausalLM")
+
+
+def test_qwen3_moe_adapter_rejects_other_architectures():
+    adapter = Qwen3MoeAdapter()
+    for arch in ("LlamaForCausalLM", "Gemma4ForConditionalGeneration",
+                 "Phi3ForCausalLM", "Qwen2ForCausalLM"):
+        with pytest.raises(ArchitectureMismatch):
+            adapter.validate_architecture(arch)
+
+
+# ── Critical: router vs expert-gate discrimination ──────────────────
+
+
+def test_router_classification_discriminates_from_expert_gate_proj():
+    """The router (``mlp.gate.weight``) is FP16-protected while the
+    expert gate projection (``mlp.experts.K.gate_proj.weight``) is
+    ternary-eligible.
+
+    This test exists because the protected-substring ``"mlp.gate."``
+    (with trailing period) is the discriminator — the underscore in
+    ``gate_proj`` breaks the substring match. Removing the trailing
+    period would silently misclassify all expert gate weights as
+    FP16-protected (cf. ``pattern_substring_pattern_discrimination_v1``).
+    """
+    adapter = Qwen3MoeAdapter()
+
+    router_cls = adapter.classify_weight(
+        "model.layers.0.mlp.gate.weight",
+        shape=[128, 2048],
+    )
+    assert router_cls.category == "fp16_retain", (
+        f"Router should be FP16-protected, got {router_cls.category}"
+    )
+    assert router_cls.expert_idx is None
+
+    expert_gate_cls = adapter.classify_weight(
+        "model.layers.0.mlp.experts.5.gate_proj.weight",
+        shape=[768, 2048],
+    )
+    assert expert_gate_cls.category == "ternary_eligible", (
+        f"Expert gate should be ternary, got {expert_gate_cls.category}"
+    )
+    assert expert_gate_cls.expert_idx == 5, (
+        f"Expected expert_idx=5, got {expert_gate_cls.expert_idx}"
+    )
+
+
+# ── Per-expert classification + expert_idx wiring ───────────────────
+
+
+@pytest.mark.parametrize(
+    "name, expected_idx",
+    [
+        ("model.layers.0.mlp.experts.0.gate_proj.weight", 0),
+        ("model.layers.0.mlp.experts.0.up_proj.weight", 0),
+        ("model.layers.0.mlp.experts.0.down_proj.weight", 0),
+        ("model.layers.0.mlp.experts.5.gate_proj.weight", 5),
+        ("model.layers.47.mlp.experts.127.down_proj.weight", 127),
+    ],
+)
+def test_per_expert_weights_classify_with_expert_idx(name, expected_idx):
+    cls = Qwen3MoeAdapter().classify_weight(name, shape=[768, 2048])
+    assert cls.category == "ternary_eligible"
+    assert cls.expert_idx == expected_idx
+
+
+# ── Attention projections ───────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "name, shape",
+    [
+        ("model.layers.0.self_attn.q_proj.weight", [4096, 2048]),
+        ("model.layers.0.self_attn.k_proj.weight", [512, 2048]),
+        ("model.layers.0.self_attn.v_proj.weight", [512, 2048]),
+        ("model.layers.0.self_attn.o_proj.weight", [2048, 4096]),
+    ],
+)
+def test_attention_projections_are_ternary_eligible(name, shape):
+    cls = Qwen3MoeAdapter().classify_weight(name, shape)
+    assert cls.category == "ternary_eligible"
+    assert cls.expert_idx is None
+
+
+# ── Norms (including Qwen3-specific q_norm / k_norm) ────────────────
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "model.layers.0.input_layernorm.weight",
+        "model.layers.0.post_attention_layernorm.weight",
+        "model.layers.0.self_attn.q_norm.weight",
+        "model.layers.0.self_attn.k_norm.weight",
+        "model.embed_tokens.weight",
+        "model.norm.weight",
+        "lm_head.weight",
+    ],
+)
+def test_qwen3_protected_patterns(name):
+    cls = Qwen3MoeAdapter().classify_weight(name, shape=[2048])
+    assert cls.category == "fp16_retain"
+    assert cls.expert_idx is None
+
+
+# ── No expand_stacked needed (Qwen3 is per-expert 2-D in safetensors) ──
+
+
+def test_qwen3_expand_stacked_returns_none_for_all_qwen3_patterns():
+    """Qwen3 stores experts as 2-D indexed tensors directly in the
+    safetensors index — no stacked-tensor expansion needed."""
+    adapter = Qwen3MoeAdapter()
+    for name, shape in (
+        ("model.layers.0.mlp.experts.0.gate_proj.weight", [768, 2048]),
+        ("model.layers.0.mlp.experts.0.down_proj.weight", [2048, 768]),
+        ("model.layers.0.mlp.gate.weight", [128, 2048]),
+        ("model.layers.0.self_attn.q_proj.weight", [4096, 2048]),
+    ):
+        assert adapter.expand_stacked(name, shape) is None, (
+            f"expand_stacked should return None for Qwen3 (no stacked "
+            f"tensors); got non-None for {name}"
+        )
+
+
+# ── expert_pattern declared on info() ──────────────────────────────
+
+
+def test_qwen3_info_declares_expert_pattern():
+    """Qwen3MoeAdapter declares expert_pattern on info() so the
+    inherited _extract_expert_idx helper works without subclass
+    overrides."""
+    info = Qwen3MoeAdapter().info()
+    assert info.expert_pattern is not None
+    # The pattern should match Qwen3's per-expert name structure
+    match = info.expert_pattern.search(
+        "model.layers.0.mlp.experts.5.gate_proj.weight"
+    )
+    assert match is not None
+    assert match.group("expert_idx") == "5"


### PR DESCRIPTION
## Summary

Cross-architecture adapter coverage for Thursday 2026-05-07's planned 3-model compression sequence (Gemma 4 31B + Qwen3-30B-A3B + Phi-4). Two new adapters + analysis pattern extensions + single-model compression script template.

## Context

PR #14 (Session 3 per-expert slicing) and PR #15 (dual-compression orchestrator) established the per-expert measurement methodology against Gemma 4 26B-A4B. Today extends the methodology to two new architectures so cross-architecture analysis can inform the briefing MoE IP section reframing decision deferred at Session 4 close.

Gemma 4 31B compression is running in background as this PR is opened (PID 28436, fired before the commit ladder); uses the existing Gemma4Adapter unchanged (verified at pre-flight: dense, `num_experts=None`, `enable_moe_block=False`).

## Adapters

**Phi3Adapter** (Phi-3 / Phi-4 dense): declares `Phi3ForCausalLM` allow-list; classification logic mirrors LlamaAdapter (validated by April 2026 prior production compression of `microsoft/phi-4` via the `--adapter llama` route — 160 ternary entries, 83 FP16, file size 6,835 MB; on-disk artefact at `/Volumes/Syn Archive/models/compressed/phi4-14b/`). Fused QKV and fused gate+up are treated as single ternary tensors; per-component sparsity expansion deferred to a future PR if cross-architecture data shows a signal worth investigating.

**Qwen3MoeAdapter** (Qwen3 MoE): declares `Qwen3MoeForCausalLM` allow-list. Per-expert weights are 2-D indexed in safetensors directly (`mlp.experts.K.{gate,up,down}_proj.weight` for K in 0..127) — no `expand_stacked` rework needed unlike Gemma 4's 3-D stacked layout. Per-expert sparsity falls out naturally from `pack_ternary` per-tensor threshold computation.

The substantive Qwen3 quirk: router weight is `mlp.gate.weight` (NOT `router.*` like Gemma 4). Discriminating from expert gate projections (`mlp.experts.K.gate_proj.weight`) via the protected substring `"mlp.gate."` with **trailing period** — the underscore in `gate_proj` breaks the substring match cleanly. Without the trailing period, all 18,432 expert gate weights would silently misclassify as FP16-protected. Test `test_router_classification_discriminates_from_expert_gate_proj` explicitly guards this regression. Methodology banked at `pattern_substring_pattern_discrimination_v1` memory.

## Architectural difference: Qwen3 has no parallel dense MLP

Qwen3MoE is pure MoE FFN (no `mlp.gate_proj.weight` / `mlp.up_proj.weight` / `mlp.down_proj.weight` at the layer top level). Distinct from Gemma 4 26B-A4B which carries both per-expert weights AND parallel dense MLP per layer. Cross-architecture analysis question therefore differs: instead of "experts vs dense within Qwen3" (the within-model comparison that produced Session 4's negative result on 26B-A4B), the substantive Qwen3 question is "do Qwen3 experts show similar absolute sparsity to Gemma 4 experts?" (cross-architecture absolute-sparsity baseline). The `qwen3_moe` MODEL_GROUP_PATTERNS entry sets `dense_ffn=[]` accordingly.

## Benchmarks

- **Single-model compression script** at `benchmarks/run_compression_gemma4_31b.py` — template for future single-model compressions (Phi-4, Qwen3 to follow).
- **Analysis patterns** for `phi3_dense` and `qwen3_moe` groups in `analyse_per_expert_tolerance.py`.

## Test coverage

- 33 new adapter tests (12 Phi3 + 21 Qwen3MoE), all passing
- Updated test_adapters_registry parametrise lists for the new adapters
- Updated test_adapters_schema_widening — Phi3Adapter to the non-MoE invariant list (Qwen3MoeAdapter excluded since it declares expert_pattern)
- **Full suite**: 473 passed, 3 skipped, 0 failures (up from Session 3's 435 baseline)

## Forward path

After PR #16 merges + Gemma 4 31B compression completes (background, PID 28436): fire Qwen3-30B-A3B compression + Phi-4 compression sequentially. Run Session-4-equivalent analyses on all three new manifests. Cross-architecture per-expert sparsity comparison vs 26B-A4B baseline informs the briefing MoE IP section reframing decision.