### PR TITLE
Session Thursday Step 4: compression scripts for Qwen3 + Phi-4

### DIFF
--- a/benchmarks/run_compression_phi4.py
+++ b/benchmarks/run_compression_phi4.py
@@ -1,0 +1,190 @@
+"""
+Phi-4 dense compression — Thursday 2026-05-07 cross-architecture sprint.
+
+Uses the new Phi3Adapter (PR #16) — declares Phi3ForCausalLM allow-list
+(Phi-4 retains Phi3 architecture class). Classification logic mirrors
+LlamaAdapter, validated by April 2026 prior production compression of
+microsoft/phi-4 (160 ternary entries, 83 FP16, file size 6,835 MB —
+artefact at /Volumes/Syn Archive/models/compressed/phi4-14b/).
+
+Fused QKV (qkv_proj.weight) and fused gate+up (gate_up_proj.weight)
+treated as single ternary tensors — matches April production behaviour
+and forward-pass shape (one nn.Linear per fused tensor).
+
+Configurational fidelity assertion derived from HF config (FLAT layout
+— no text_config nesting). For Phi-4 (40 layers, dense, 4 ternary
+projections per layer): 40 × 4 = 160 expected ternary entries. This
+matches April production exactly.
+
+Single-model template form copied from
+``run_compression_gemma4_31b.py`` with Phi-4-specific constants +
+formula.
+
+Usage:
+    python benchmarks/run_compression_phi4.py
+
+Wall-clock estimate: ~25-40 min on M4 Pro. Phi-4 is ~14B (smaller
+than 26B-A4B's 26B); only 160 ternary entries (vs 7,875 for 26B-A4B);
+per-tensor processing should dominate but with far fewer entries.
+
+Copyright (c) 2026 Gamma Seeds Pte Ltd. All rights reserved.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+from terncore.convert import full_convert
+
+
+# ── Sprint constants ────────────────────────────────────────────────
+
+SOURCE_HF_ID = "microsoft/phi-4"
+OUTPUT_DIR = Path(
+    "/Volumes/Syn Archive/models/compressed/phi-4/"
+    "phi4_14b_ternary_v0.1.1.tern-model"
+)
+ADAPTER_NAME = "phi3"
+THRESHOLD = 0.7
+# Smaller absolute tolerance for Phi-4 (smaller total count means ±65
+# would be ~40% of expected — too loose). ±10 = ~6%.
+TOLERANCE = 10
+
+
+# ── Architectural ground truth ──────────────────────────────────────
+
+
+def compute_expected_ternary_count(text_config: dict) -> int:
+    """Architectural ground truth for Phi-4 (dense, fused projections).
+
+    Per-layer breakdown:
+    - 1 fused QKV (qkv_proj.weight)
+    - 1 separate o_proj.weight
+    - 1 fused gate_up (gate_up_proj.weight)
+    - 1 separate down_proj.weight
+    = 4 ternary-eligible tensors per layer
+
+    For Phi-4 (40 layers): 40 × 4 = 160. Matches April 2026
+    production compression exactly (verified in
+    /Volumes/Syn Archive/models/compressed/phi4-14b/
+    phi4_14b_ternary_v0.1.0_conversion_report.json — ternary_layers: 160).
+    """
+    num_layers = text_config["num_hidden_layers"]
+    per_layer = 4  # qkv_proj + o_proj + gate_up_proj + down_proj
+    return num_layers * per_layer
+
+
+def assert_configurational_fidelity(
+    report: dict, expected: int, tolerance: int = TOLERANCE,
+) -> None:
+    """Hard guard on ternary_layers count vs HF-derived expectation."""
+    actual = report["ternary_layers"]
+    if not (expected - tolerance <= actual <= expected + tolerance):
+        raise ValueError(
+            f"Configurational fidelity violation: expected ~{expected} "
+            f"(±{tolerance}), got {actual}. Full report: {report}"
+        )
+
+
+def load_text_config_via_hf(hf_id: str) -> dict:
+    """Resolve text_config via huggingface_hub (cache-aware).
+
+    Falls back to top-level config when text_config isn't nested
+    (Phi-4's config layout is flat).
+    """
+    from huggingface_hub import snapshot_download
+    config_dir = snapshot_download(hf_id, allow_patterns=["config.json"])
+    with open(Path(config_dir) / "config.json") as f:
+        cfg = json.load(f)
+    return cfg.get("text_config", cfg)
+
+
+def write_run_summary(
+    report: dict,
+    expected: int,
+    output_dir: Path,
+    label: str,
+    started_at: str,
+    finished_at: str,
+    wall_clock_seconds: float,
+) -> None:
+    summary = {
+        "label": label,
+        "input_source": report.get("model_id"),
+        "output_path": report.get("output_path"),
+        "threshold": report.get("threshold"),
+        "ternary_layers": report["ternary_layers"],
+        "ternary_params": report["ternary_params"],
+        "expected_ternary_count": expected,
+        "tolerance_band": [expected - TOLERANCE, expected + TOLERANCE],
+        "fidelity_pass": True,
+        "fp16_layers": report["fp16_layers"],
+        "fp16_params": report["fp16_params"],
+        "int4_layers": report["int4_layers"],
+        "int4_params": report["int4_params"],
+        "compression_vs_fp16": report.get("compression_vs_fp16"),
+        "file_size_bytes": report.get("file_size_bytes"),
+        "wall_clock_seconds": round(wall_clock_seconds, 2),
+        "started_at": started_at,
+        "finished_at": finished_at,
+    }
+    summary_path = output_dir / "run_summary.json"
+    summary_path.write_text(json.dumps(summary, indent=2) + "\n")
+    print(f"[ok] run_summary written: {summary_path}", flush=True)
+
+
+# ── Main ────────────────────────────────────────────────────────────
+
+
+def main() -> int:
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    started_at = datetime.now(timezone.utc).isoformat()
+    t_start = time.perf_counter()
+    print(
+        f"\n[{started_at}] Run starting: phi4_14b_dense\n"
+        f"  source: {SOURCE_HF_ID}\n"
+        f"  output: {OUTPUT_DIR}\n"
+        f"  adapter: {ADAPTER_NAME}",
+        flush=True,
+    )
+
+    text_config = load_text_config_via_hf(SOURCE_HF_ID)
+    expected = compute_expected_ternary_count(text_config)
+    print(
+        f"  Expected ternary count: ~{expected} (±{TOLERANCE}; "
+        f"{text_config['num_hidden_layers']} layers × 4 ternary "
+        f"per layer — matches April 2026 production validation)",
+        flush=True,
+    )
+
+    report = full_convert(
+        model_id=SOURCE_HF_ID,
+        adapter_name=ADAPTER_NAME,
+        output_dir=str(OUTPUT_DIR),
+        threshold=THRESHOLD,
+        verbose=True,
+    )
+
+    wall_clock = time.perf_counter() - t_start
+    finished_at = datetime.now(timezone.utc).isoformat()
+    assert_configurational_fidelity(report, expected)
+    write_run_summary(
+        report, expected, OUTPUT_DIR, "phi4_14b_dense",
+        started_at, finished_at, wall_clock,
+    )
+    print(
+        f"\n[{finished_at}] Run complete: phi4_14b_dense "
+        f"({wall_clock / 60:.1f} min wall)\n"
+        f"  ternary_layers: {report['ternary_layers']} "
+        f"(expected ~{expected}, ±{TOLERANCE}) — PASS",
+        flush=True,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmarks/run_compression_qwen3_30b_a3b.py
+++ b/benchmarks/run_compression_qwen3_30b_a3b.py
@@ -1,0 +1,189 @@
+"""
+Qwen3-30B-A3B MoE compression — Thursday 2026-05-07 cross-architecture sprint.
+
+Uses the new Qwen3MoeAdapter (PR #16) — declares Qwen3MoeForCausalLM
+allow-list and handles per-expert 2-D indexed tensors directly (no
+expand_stacked needed since Qwen3 stores experts as separate
+``mlp.experts.K.{gate,up,down}_proj.weight`` entries in safetensors,
+unlike Gemma 4's 3-D stacked pattern).
+
+Configurational fidelity assertion derived from HF config per Q5
+design — Qwen3's config is FLAT (no ``text_config`` nesting like
+Gemma 4's multimodal config); the helper handles both layouts via
+``cfg.get("text_config", cfg)`` fallback.
+
+For Qwen3-30B-A3B (128 experts, 48 layers, no parallel dense MLP):
+48 × (128 × 3 + 4) = 48 × 388 = 18,624 expected ternary entries.
+
+Single-model template form copied from
+``run_compression_gemma4_31b.py`` with Qwen3-specific constants +
+formula. Future single-model MoE compressions (different num_experts,
+num_layers) can copy this script and modify the constants section.
+
+Usage:
+    python benchmarks/run_compression_qwen3_30b_a3b.py
+
+Wall-clock estimate: ~45-90 min on M4 Pro. Qwen3 has 18,624 ternary
+entries (vs Gemma 4 26B-A4B's ~7,875), so per-tensor processing
+dominates wall-clock — likely longer than 26B-A4B's 42 min.
+
+Copyright (c) 2026 Gamma Seeds Pte Ltd. All rights reserved.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+from terncore.convert import full_convert
+
+
+# ── Sprint constants ────────────────────────────────────────────────
+
+SOURCE_HF_ID = "Qwen/Qwen3-30B-A3B"
+OUTPUT_DIR = Path(
+    "/Volumes/Syn Archive/models/compressed/qwen3-30b-a3b/"
+    "qwen3_30b_a3b_ternary_v0.1.0.tern-model"
+)
+ADAPTER_NAME = "qwen3_moe"
+THRESHOLD = 0.7
+TOLERANCE = 65
+
+
+# ── Architectural ground truth ──────────────────────────────────────
+
+
+def compute_expected_ternary_count(text_config: dict) -> int:
+    """Architectural ground truth for Qwen3MoE ternary-eligible count.
+
+    Per-layer breakdown (no parallel dense MLP — pure MoE FFN):
+    - ``num_experts × 3`` per-expert weights (gate_proj, up_proj,
+      down_proj — separate tensors per expert, NOT fused like Gemma 4)
+    - 4 attention weights (q, k, v, o; no sliding/full split for
+      Qwen3 — uniform attention across layers)
+
+    Generalises across Qwen3MoE family by reading num_experts +
+    num_hidden_layers from config. For 30B-A3B (128 experts, 48
+    layers): 48 * (128*3 + 4) = 48 * 388 = 18,624.
+    """
+    num_experts = text_config["num_experts"]
+    num_layers = text_config["num_hidden_layers"]
+    per_layer_expert = 3 * num_experts
+    per_layer_attn = 4
+    return num_layers * (per_layer_expert + per_layer_attn)
+
+
+def assert_configurational_fidelity(
+    report: dict, expected: int, tolerance: int = TOLERANCE,
+) -> None:
+    """Hard guard on ternary_layers count vs HF-derived expectation."""
+    actual = report["ternary_layers"]
+    if not (expected - tolerance <= actual <= expected + tolerance):
+        raise ValueError(
+            f"Configurational fidelity violation: expected ~{expected} "
+            f"(±{tolerance}), got {actual}. Full report: {report}"
+        )
+
+
+def load_text_config_via_hf(hf_id: str) -> dict:
+    """Resolve text_config via huggingface_hub (cache-aware).
+
+    Falls back to top-level config when ``text_config`` isn't nested
+    (Qwen3's config layout, vs Gemma 4's nested multimodal layout).
+    """
+    from huggingface_hub import snapshot_download
+    config_dir = snapshot_download(hf_id, allow_patterns=["config.json"])
+    with open(Path(config_dir) / "config.json") as f:
+        cfg = json.load(f)
+    return cfg.get("text_config", cfg)
+
+
+def write_run_summary(
+    report: dict,
+    expected: int,
+    output_dir: Path,
+    label: str,
+    started_at: str,
+    finished_at: str,
+    wall_clock_seconds: float,
+) -> None:
+    summary = {
+        "label": label,
+        "input_source": report.get("model_id"),
+        "output_path": report.get("output_path"),
+        "threshold": report.get("threshold"),
+        "ternary_layers": report["ternary_layers"],
+        "ternary_params": report["ternary_params"],
+        "expected_ternary_count": expected,
+        "tolerance_band": [expected - TOLERANCE, expected + TOLERANCE],
+        "fidelity_pass": True,
+        "fp16_layers": report["fp16_layers"],
+        "fp16_params": report["fp16_params"],
+        "int4_layers": report["int4_layers"],
+        "int4_params": report["int4_params"],
+        "compression_vs_fp16": report.get("compression_vs_fp16"),
+        "file_size_bytes": report.get("file_size_bytes"),
+        "wall_clock_seconds": round(wall_clock_seconds, 2),
+        "started_at": started_at,
+        "finished_at": finished_at,
+    }
+    summary_path = output_dir / "run_summary.json"
+    summary_path.write_text(json.dumps(summary, indent=2) + "\n")
+    print(f"[ok] run_summary written: {summary_path}", flush=True)
+
+
+# ── Main ────────────────────────────────────────────────────────────
+
+
+def main() -> int:
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    started_at = datetime.now(timezone.utc).isoformat()
+    t_start = time.perf_counter()
+    print(
+        f"\n[{started_at}] Run starting: qwen3_30b_a3b_moe\n"
+        f"  source: {SOURCE_HF_ID}\n"
+        f"  output: {OUTPUT_DIR}\n"
+        f"  adapter: {ADAPTER_NAME}",
+        flush=True,
+    )
+
+    text_config = load_text_config_via_hf(SOURCE_HF_ID)
+    expected = compute_expected_ternary_count(text_config)
+    print(
+        f"  Expected ternary count: ~{expected} (±{TOLERANCE}; "
+        f"{text_config['num_experts']} experts × 3 + 4 attn = "
+        f"{3 * text_config['num_experts'] + 4} per layer × "
+        f"{text_config['num_hidden_layers']} layers)",
+        flush=True,
+    )
+
+    report = full_convert(
+        model_id=SOURCE_HF_ID,
+        adapter_name=ADAPTER_NAME,
+        output_dir=str(OUTPUT_DIR),
+        threshold=THRESHOLD,
+        verbose=True,
+    )
+
+    wall_clock = time.perf_counter() - t_start
+    finished_at = datetime.now(timezone.utc).isoformat()
+    assert_configurational_fidelity(report, expected)
+    write_run_summary(
+        report, expected, OUTPUT_DIR, "qwen3_30b_a3b_moe",
+        started_at, finished_at, wall_clock,
+    )
+    print(
+        f"\n[{finished_at}] Run complete: qwen3_30b_a3b_moe "
+        f"({wall_clock / 60:.1f} min wall)\n"
+        f"  ternary_layers: {report['ternary_layers']} "
+        f"(expected ~{expected}, ±{TOLERANCE}) — PASS",
+        flush=True,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Two new single-model compression scripts using the adapters from PR #16. Templates mirror the gemma4_31b script structure for consistent run_summary.json output across Thursday's cross-architecture sprint.

## Configurational fidelity assertions

Both formulas derived from HF config (Q5 design pattern):

- **Qwen3-30B-A3B**: `48 layers × (128 experts × 3 + 4 attention) = 18,624` expected ternary entries. Tolerance ±65.
- **Phi-4**: `40 layers × 4 per-layer fused = 160` expected ternary entries. Tolerance ±10. Validated against April 2026 prior production compression which produced exactly 160 entries via `--adapter llama` route.

Both formulas verified locally via smoke test (see commit body).

## Architecture-aware design

- **Qwen3**: pure MoE FFN (no parallel dense MLP), per-expert 2-D indexed tensors, router as `mlp.gate.weight` discriminated from expert gate via the `mlp.gate.` substring (PR #16 methodology).
- **Phi-4**: dense, fused QKV + fused gate_up treated as single ternary tensors per "smallest principled change first" (deferring per-component slicing until cross-architecture analysis surfaces a signal worth investigating).

## Cross-architecture context

Companion to PR #16 (adapters). Together they enable Thursday's 3-model compression sequence:
- Gemma 4 31B (already complete via PR #16's gemma4_31b script — 410 ternary, 4.18× compression, 53.4 min wall, configurational fidelity PASS)
- Qwen3-30B-A3B (next, blocked on this PR)
- Phi-4 (next, blocked on this PR)

## Forward path

Once merged: fire Qwen3 compression first (substantive cross-architecture data point, ~45-90 min wall — Qwen3 has 18,624 ternary entries vs 26B-A4B's 7,875), then Phi-4 (smaller dense baseline, ~25-40 min wall). Run Session-4-equivalent analyses on both new manifests. Cross-architecture per-expert sparsity comparison vs 26B-A4B baseline informs the briefing MoE IP section reframing decision.