### PR TITLE
b_mse parameterisation on IncrementalTQCompressor (R12 §8.1 partial — factory deferred pending round-trip design)

### DIFF
--- a/tools/tern_infer.py
+++ b/tools/tern_infer.py
@@ -152,14 +152,15 @@ class IncrementalTQCompressor:
     encodes only newly-appended vectors on each call to `append`.
     """
 
-    def __init__(self, n_layers: int, n_heads: int, head_dim: int, device="cpu"):
+    def __init__(self, n_layers: int, n_heads: int, head_dim: int, device="cpu", b_mse: int = 3):
         sys.path.insert(0, "/Users/syn/synapticode/venv/src/turboquant")
         from src.cache import TurboQuantConfig
 
         self.n_layers = n_layers
         self.n_heads = n_heads
+        self.b_mse = b_mse
         self.config = TurboQuantConfig(
-            d=head_dim, b_mse=3,
+            d=head_dim, b_mse=self.b_mse,
             device=torch.device(device), mixed_precision=True,
         )
         # Pre-build per-layer, per-head rotation + QJL state
@@ -219,6 +220,7 @@ class IncrementalTQCompressor:
 
 def generate_streaming_turboquant(
     model, tokenizer, prompt: str, max_tokens: int = DEFAULT_MAX_TOKENS,
+    b_mse: int = 3,
 ) -> tuple[str, float, int]:
     """Generate with KV cache + incremental TurboQuant compression.
 
@@ -258,6 +260,7 @@ def generate_streaming_turboquant(
                     n_layers=len(kv0),
                     n_heads=kv0[0][0].shape[1],
                     head_dim=kv0[0][0].shape[3],
+                    b_mse=b_mse,
                 )
 
             # Encode only the new position(s) since last call


### PR DESCRIPTION
## Summary

Parameterises `b_mse` on `IncrementalTQCompressor` and forwards it through `generate_streaming_turboquant`. Partial satisfaction of R12 v1.0 §8.1 (PR #24) — the parameterisation half lands; the `make_b_mse_hook` factory is deferred pending a logically prior workstream (see Deferred below).

## Why now

R12 v1.0 (PR #24) landed as documented-but-unexecutable: the methodology requires per-call `b_mse` variation across the sweep `{6,5,4,3,2,1}`, but `IncrementalTQCompressor` hardcoded `b_mse=3` at `tools/tern_infer.py:162`. This PR hoists `b_mse` to a constructor kwarg with `default=3` so all current behaviour is preserved at default.

## Changes

1. `IncrementalTQCompressor.__init__` accepts `b_mse: int = 3`; `self.b_mse` stored for introspection
2. `TurboQuantConfig(...)` instantiation now uses `b_mse=self.b_mse` (was hardcoded literal `3`)
3. `generate_streaming_turboquant` grows a `b_mse: int = 3` kwarg, forwards to the `IncrementalTQCompressor` lazy-init. Existing callers retain prior behaviour at the default. (Path 3a per the briefing — future-proof; per-call b_mse variation is available without monkey-patching.)

Diff stat: **5 insertions, 2 deletions, 1 file** (`tools/tern_infer.py`).

## Verification

- Signature check via `inspect.signature`:
  - `IncrementalTQCompressor.__init__(self, n_layers, n_heads, head_dim, device='cpu', b_mse: int = 3)`
  - `generate_streaming_turboquant(model, tokenizer, prompt, max_tokens=50, b_mse: int = 3) -> tuple[str, float, int]`
- Construction smoke test (`n_layers=1, n_heads=1, head_dim=64`): default → `c.b_mse == 3`; explicit `b_mse=4` → `c.b_mse == 4` ✓
- No targeted tests for `tern_infer.py` exist in `tests/` (no `test_tern_infer.py`); structural verification is the proof here
- `ruff` not present in venv at run time; manual review confirms no syntax/typing concerns

## Deferred — `make_b_mse_hook` factory + round-trip design

R7-B v1.0 §5.2 specifies a `make_b_mse_hook(b_mse: int)` factory whose hook body wraps `IncrementalTQCompressor` and is invoked between forward passes in the R7-B autoregressive loop. Phase A of this refactor surfaced that this factory cannot be authored as a meaningful body against the current class:

- `IncrementalTQCompressor.append(past_kv)` returns **None** (mutates `self.compressed`); the public method name is `.append()`, not `.compress()`
- `self.compressed` holds **TurboQuant-encoded representations** (nested list of `(k_c, v_c)` tuples), not HF `past_key_values` shape
- No decode/reinjection path is exposed in `tern_infer.py` (only `turboquant_encode_internal` imported; no decode counterpart)
- The R7-B canonical loop requires the hook to RETURN valid `past_key_values` for the model's next forward call

The factory cannot do round-trip compression on the current API. Designing the compress → decompress → reinject path is a separate workstream — likely scoped at 1+ session of its own.

The R12 v1.0 §8.1 framing implicitly conflated parameterisation (this PR, small) with that round-trip design (substantial); the §8.1 text should be amended in an R12 v1.1 cascade once the round-trip design lands. PR #24 is correctable in v1.1; **not force-updating it here**.

## Cross-references

- `docs/kv_cache_compression_ppl_headroom_diagnostic.md §8.1` (PR #24) — implementation prerequisite this PR partially satisfies
- `docs/wikitext2_ppl_methodology_autoregressive.md §5.2` (PR #23) — factory signature specification (deferred work)

## Bonus IP-hygiene finding (separate backlog item)

`tools/tern_infer.py:156` carries `sys.path.insert(0, "/Users/syn/synapticode/venv/src/turboquant")` — local-machine path hardcoding, same pattern that was stripped from R12 v1.0 §10 docs. Surfaced during this refactor's Phase A. Out of scope for this PR; deserves its own small cleanup PR (replace with proper packaging / pip install -e of TurboQuant, remove sys.path.insert).

## Merge ordering

No hard dependency on PRs #20, #23, #24. Cross-references are textual; merge independently.