### PR TITLE
make_b_mse_hook factory + round-trip via turboquant_decode_single (R12 §8.1 step 4)

### DIFF
--- a/tools/tern_infer.py
+++ b/tools/tern_infer.py
@@ -218,6 +218,89 @@ class IncrementalTQCompressor:
         self.seq_len = total_seq
 
 
+def make_b_mse_hook(
+    b_mse: int,
+    n_layers: int,
+    n_heads: int,
+    head_dim: int,
+    device: str = "cpu",
+):
+    """Factory producing a kv_cache_hook closure for R7-B v1.0 §5 canonical loop.
+
+    Consumed by R12 v1.0 KV-cache-compression PPL diagnostic
+    (docs/kv_cache_compression_ppl_headroom_diagnostic.md). The returned hook
+    round-trips past_key_values through encode → decode using TurboQuant
+    Algorithm 2 (unbiased — turboquant_decode_single), returning HF-shape
+    past_key_values for the next forward call in the autoregressive loop.
+
+    Round-trip body matches turboquant/src/test_real_model.py:100-135 pattern
+    with turboquant_decode_single substituted for polarquant_decode (unbiased
+    decode preserves attention inner products for PPL fidelity).
+
+    Per-sequence semantics: fresh closure per make_b_mse_hook call; the closure
+    captures per-(layer, head) rotation and QJL state. Within-sequence: each
+    hook invocation re-encodes the full past_kv (no incremental cache); cost
+    O(L) per call, O(L²) total across an L-token sequence.
+
+    Args:
+        b_mse: bits-of-MSE quantisation parameter (sweep axis for R12)
+        n_layers, n_heads, head_dim: cache shape (must match the model)
+        device: TurboQuant config device ("cpu" or "mps")
+
+    Returns:
+        Callable[(past_key_values) -> past_key_values] suitable for direct
+        injection as kv_cache_hook in R7-B v1.0 §5 autoregressive_ppl.
+    """
+    sys.path.insert(0, "/Users/syn/synapticode/venv/src/turboquant")
+    from src.cache import (
+        TurboQuantConfig,
+        turboquant_encode_internal,
+        turboquant_decode_single,
+    )
+
+    config = TurboQuantConfig(
+        d=head_dim, b_mse=b_mse,
+        device=torch.device(device), mixed_precision=True,
+    )
+    # Pre-build per-(layer, head) rotation + QJL state once at factory time
+    rotations = [
+        [config.make_rotation(l, h) for h in range(n_heads)]
+        for l in range(n_layers)
+    ]
+    qjl_matrices = [
+        [config.make_qjl_matrix(l, h) for h in range(n_heads)]
+        for l in range(n_layers)
+    ]
+
+    def hook(past_key_values):
+        kv_pairs = _extract_kv_pairs(past_key_values)
+        new_past = []
+        for layer_idx, (k, v) in enumerate(kv_pairs):
+            batch, n_h, seq_len, hd = k.shape
+            new_k = torch.empty_like(k)
+            new_v = torch.empty_like(v)
+            for head_idx in range(n_h):
+                rotation = rotations[layer_idx][head_idx]
+                S = qjl_matrices[layer_idx][head_idx]
+                k_flat = k[:, head_idx, :, :].reshape(-1, hd).float().to(config.device)
+                v_flat = v[:, head_idx, :, :].reshape(-1, hd).float().to(config.device)
+                mixed = config.get_mixed_config(layer_idx, head_idx, k_flat)
+                k_c = turboquant_encode_internal(
+                    k_flat, config.codebook, rotation, S, mixed=mixed,
+                )
+                v_c = turboquant_encode_internal(
+                    v_flat, config.codebook, rotation, S, mixed=mixed,
+                )
+                k_recon = turboquant_decode_single(k_c)[..., :hd].contiguous()
+                v_recon = turboquant_decode_single(v_c)[..., :hd].contiguous()
+                new_k[:, head_idx] = k_recon.reshape(batch, seq_len, hd).to(k.dtype)
+                new_v[:, head_idx] = v_recon.reshape(batch, seq_len, hd).to(v.dtype)
+            new_past.append((new_k, new_v))
+        return tuple(new_past)
+
+    return hook
+
+
 def generate_streaming_turboquant(
     model, tokenizer, prompt: str, max_tokens: int = DEFAULT_MAX_TOKENS,
     b_mse: int = 3,


### PR DESCRIPTION
## Summary

Authors the `make_b_mse_hook(b_mse, n_layers, n_heads, head_dim, device)` factory referenced in R7-B v1.0 §5.2 and consumed by R12 v1.0's KV-cache-compression PPL diagnostic. **Second half of the R12 §8.1 implementation prerequisite** (first half — `b_mse` parameterisation — landed at `03fe4f6` via PR #25).

R12 first execution is **functionally unblocked**: methodology is now executable end-to-end, but wall-time per sweep is substantial (see Wall-time projection below).

## Round-trip approach: Option α (native TurboQuant decode)

Phase A survey found TurboQuant exposes both biased (`polarquant_decode`) and unbiased (`turboquant_decode_single`) decoders. Surgeon disposition: **unbiased**, because R12 measures PPL via attention which depends on inner products — Algorithm 2's QJL residual correction preserves those.

Hook body mirrors `turboquant/src/test_real_model.py:100-135` (the existing reference round-trip pattern that produced the 12 May `tq_bench_results.json`), with `turboquant_decode_single` substituted for `polarquant_decode`.

## Disposition record

| Knob | Disposition |
|---|---|
| Decoder | `turboquant_decode_single` (unbiased, full Algorithm 2) |
| Per-sequence semantics | Fresh closure per `make_b_mse_hook` call; closure captures per-(layer, head) rotation + QJL state |
| Within-sequence state | Full re-encode each hook call (no incremental cache); matches `test_real_model.py:100-135` pattern |
| Fidelity bar | Cosine similarity ≥ 0.95 per layer for K and V independently |
| Wall-time tolerance | Proceed past v0.1 + surface measured per-hook latency, even if 3-5× R7-B baseline |

## Verification

### Fidelity — well above bar

Smoke test on `n_layers=2, n_heads=4, head_dim=64, L=8` synthetic past_kv (`torch.manual_seed(1337)`):

| Layer | k_cos | v_cos |
|---|---|---|
| 0 | 0.9969 | 0.9962 |
| 1 | 0.9961 | 0.9957 |

All values comfortably above 0.95 threshold. Round-trip preserves attention inner products as Algorithm 2 promises.

### Latency — characterised

TinyLlama-realistic dims (`n_layers=22, n_heads=32, head_dim=64`, CPU on M4 Pro):

| Measurement | Value |
|---|---|
| Factory build (one-time) | 0.2 s |
| Cold first-hook call (one-time Lloyd-Max codebook compute) | ~11 min |
| Warm calls at L=8 | 614, 632, 614 ms (avg 620 ms) |
| Warm calls at L=32 | 641, 652, 643 ms (avg 645 ms) |
| Warm calls at L=64 | 697, 702, 697 ms (avg 699 ms) |

Per-call cost is roughly **L-independent** in the L=8 to L=64 range — dominated by the 704-iteration `for layer in n_layers: for head in n_heads:` Python loop, not by per-token encode/decode work.

### Wall-time projection for R12 first execution on TinyLlama-1.1B

Assuming ~700ms warm-call cost at L=2048 (extrapolating from L=64 plateau):

| Scope | Projected time |
|---|---|
| Per hook call | ~700 ms |
| Per sequence (~2048 forward calls) | ~24 min |
| Per sweep point (16 sequences + ~11 min cold) | ~6.6 hours |
| **Full 6-point sweep** | **~40 hours** |

This is ~13× the "~3 hours" estimate documented in R12 v1.0 §8. The overrun is **in the pure-Python TurboQuant encode/decode path**; `kernels.py` provides a Triton-accelerated alternative gated on Triton being importable in the venv.

## Cross-references

- PR #24 — R12 v1.0 spec (`docs/kv_cache_compression_ppl_headroom_diagnostic.md`); this PR completes §8.1 step 4
- Commit `03fe4f6` (PR #25 merged) — `b_mse` parameterisation refactor; this PR is the round-trip half of R12 §8.1
- `turboquant/src/test_real_model.py:100-135` — reference round-trip pattern
- `turboquant/src/cache.py:821` — `turboquant_decode_single` definition (Algorithm 2)
- `turboquant/src/kernels.py` — Triton-accelerated alternatives (optimization path for v1.1)

## Amendment recommendations (NOT included in this PR — surfaced for future cascades)

**R12 v1.1 amendments** (when next R12 cascade fires):
- §8 first-execution wall-time estimate: revise from ~3h → ~40h on pure-Python path
- §8.1 add note that the four bullets were not "<1 surgeon session" combined — round-trip design was its own design+implement session
- §8.2 (new) — optimization path: Triton kernels in `turboquant/src/kernels.py`, or batched per-(layer, head) encode

**R7-B v1.1 amendments** (when next R7-B cascade fires):
- §5.2 — clarify hook factory lifetime semantics (factory-per-sweep-point) and expected cost band; the current pseudocode is shape-correct but implicitly assumed cost is marginal vs forward pass

## Merge ordering

No hard dependency on other PRs. Cross-references resolve in main (PRs #20, #23, #24, #25 all merged).