### PR TITLE
fix(tern_infer): replace hardcoded turboquant path with env-var + repo-relative helper

### DIFF
--- a/tests/test_ppl_bench_methodology.py
+++ b/tests/test_ppl_bench_methodology.py
@@ -799,18 +799,6 @@ def test_autoregressive_real_model_tinyllama_with_hook_cpu():
     except ImportError:
         pytest.skip("transformers not installed")
 
-    # tern_infer's make_b_mse_hook_uniform imports from a hardcoded local
-    # turboquant path (tern_infer.py:345). CI runners lack this path. Skip
-    # if the module isn't resolvable — carry-forward: declare turboquant as
-    # a proper pyproject.toml dep or replace hardcoded path with env-var +
-    # repo-relative fallback (affects both PR #26 and PR #27 hooks).
-    try:
-        from tern_infer import make_b_mse_hook_uniform  # noqa: F401
-    except (ImportError, ModuleNotFoundError) as e:
-        pytest.skip(
-            f"turboquant package path not available on this runner: {e}"
-        )
-
     model_id = "TinyLlama/TinyLlama-1.1B-Chat-v1.0"
     tokenizer = AutoTokenizer.from_pretrained(model_id)
     model = AutoModelForCausalLM.from_pretrained(
@@ -833,9 +821,18 @@ def test_autoregressive_real_model_tinyllama_with_hook_cpu():
     )
     assert len(sequences) == 1
 
-    hook, params, factory_seconds = tern_ppl_bench.build_kv_cache_hook(
-        hook_spec="uniform", b_mse=4, model=model, device=device
-    )
+    # tern_infer's hook factories use _ensure_turboquant_on_path() to locate
+    # the turboquant source directory. CI runners typically lack the canonical
+    # ../venv/src/turboquant layout AND the TURBOQUANT_DEV_PATH env-var, so
+    # the helper raises ImportError when called from build_kv_cache_hook.
+    # Skip when turboquant is unreachable; the test still runs on dev boxes
+    # where the canonical layout exists.
+    try:
+        hook, params, factory_seconds = tern_ppl_bench.build_kv_cache_hook(
+            hook_spec="uniform", b_mse=4, model=model, device=device
+        )
+    except ImportError as e:
+        pytest.skip(f"turboquant package path not available on this runner: {e}")
     assert hook is not None
     assert params["factory_name"] == "make_b_mse_hook_uniform"
     assert factory_seconds > 0  # cold path exercised

--- a/tools/tern_infer.py
+++ b/tools/tern_infer.py
@@ -30,6 +30,58 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 
 from terncore.mixed_precision import MixedPrecisionConverter
 
+
+def _ensure_turboquant_on_path() -> None:
+    """Resolve turboquant's source directory and add it to sys.path.
+
+    Background: turboquant 0.1.0 has an upstream packaging bug. Its setup.py
+    uses find_packages() which discovered the src/ directory as a top-level
+    package literally named 'src'. As a result, ``from turboquant.cache import
+    ...`` fails (ModuleNotFoundError: No module named 'turboquant') even
+    though pip metadata reports turboquant 0.1.0 installed. The working
+    import is ``from src.cache import ...`` after sys.path is augmented with
+    the parent of the src/ directory.
+
+    Discovery order:
+      1. ``TURBOQUANT_DEV_PATH`` environment variable (if set + path exists)
+      2. Repo-relative fallback: ``<tern-core-root>/../venv/src/turboquant``
+      3. Raise ImportError with diagnostic message
+
+    Future work: when upstream turboquant lands ``package_dir={"turboquant":
+    "src"}, packages=["turboquant"]`` (or migrates to a pyproject.toml-based
+    src layout), this helper can be removed and replaced with direct ``from
+    turboquant.cache import ...`` imports across all consumer sites. Tracked
+    as carry-forward; not in scope for this fix.
+    """
+    import os
+
+    candidates: list[tuple[str, Path]] = []
+    env_path = os.environ.get("TURBOQUANT_DEV_PATH")
+    if env_path:
+        candidates.append(("TURBOQUANT_DEV_PATH env-var", Path(env_path)))
+
+    # Repo-relative fallback: this file is tern-core/tools/tern_infer.py;
+    # canonical dev-box layout is sibling venv at ../venv/src/turboquant.
+    repo_root = Path(__file__).resolve().parent.parent  # tern-core/
+    fallback = repo_root.parent / "venv" / "src" / "turboquant"
+    candidates.append(("repo-relative ../venv/src/turboquant", fallback))
+
+    for label, path in candidates:
+        if path.is_dir() and (path / "src" / "cache.py").is_file():
+            path_str = str(path)
+            if path_str not in sys.path:
+                sys.path.insert(0, path_str)
+            return
+
+    searched = "\n".join(f"  - {label}: {p}" for label, p in candidates)
+    raise ImportError(
+        "turboquant package path not resolvable; searched:\n"
+        f"{searched}\n"
+        "Set TURBOQUANT_DEV_PATH env-var to override, or ensure the "
+        "repo-relative venv/src/turboquant layout is present."
+    )
+
+
 DEFAULT_MODEL_ID = "TinyLlama/TinyLlama-1.1B-Chat-v1.0"
 DEFAULT_MAX_TOKENS = 50
 
@@ -153,7 +205,7 @@ class IncrementalTQCompressor:
     """
 
     def __init__(self, n_layers: int, n_heads: int, head_dim: int, device="cpu", b_mse: int = 3):
-        sys.path.insert(0, "/Users/syn/synapticode/venv/src/turboquant")
+        _ensure_turboquant_on_path()
         from src.cache import TurboQuantConfig
 
         self.n_layers = n_layers
@@ -251,7 +303,7 @@ def make_b_mse_hook(
         Callable[(past_key_values) -> past_key_values] suitable for direct
         injection as kv_cache_hook in R7-B v1.0 §5 autoregressive_ppl.
     """
-    sys.path.insert(0, "/Users/syn/synapticode/venv/src/turboquant")
+    _ensure_turboquant_on_path()
     from src.cache import (
         TurboQuantConfig,
         turboquant_encode_internal,
@@ -341,7 +393,7 @@ def make_b_mse_hook_uniform(
     import math
     import torch.nn.functional as F
 
-    sys.path.insert(0, "/Users/syn/synapticode/venv/src/turboquant")
+    _ensure_turboquant_on_path()
     from src.cache import TurboQuantConfig, fwht_inplace, EPS
 
     config = TurboQuantConfig(


### PR DESCRIPTION
## Summary

Carry-forward fix from PR #30 CI escalation. Replaces three parallel hardcoded `sys.path.insert(0, "/Users/syn/synapticode/venv/src/turboquant")` lines in `tools/tern_infer.py` with a single module-level helper `_ensure_turboquant_on_path()`.

## Phase A finding — three sites, not two

The original carry-forward note in PR #30 body named two sites (the two factories from PR #26 + #27). Phase A grep against `origin/main` found three:

| File:line | Container | PR provenance |
|---|---|---|
| `tools/tern_infer.py:156` | `IncrementalTQCompressor.__init__` | PR #25-era (existed before today; missed in carry-forward note) |
| `tools/tern_infer.py:254` | `make_b_mse_hook` | PR #26 (merged today) |
| `tools/tern_infer.py:344` | `make_b_mse_hook_uniform` | PR #27 (merged today) |

All three addressed in this fix.

## Approach (β disposition: env-var + repo-relative fallback)

Single module-level helper called from all three sites. Discovery order:

1. `TURBOQUANT_DEV_PATH` environment variable (if set + path exists)
2. Repo-relative fallback: `<tern-core-root>/../venv/src/turboquant`
3. `ImportError` with diagnostic message listing both candidates searched

α (declare turboquant in pyproject.toml) was structurally dead per Phase A: turboquant 0.1.0 has an upstream packaging bug — `setup.py` uses `find_packages()` which discovered `src/` as a top-level package literally named `src`, not `turboquant`. So `from turboquant.cache import ...` fails (ModuleNotFoundError) even though pip metadata reports turboquant 0.1.0 installed. Helper docstring documents this background for future readers.

γ (try `from turboquant.cache` first, fall back) reduces to β in practice today since the `turboquant.cache` branch is dead code until upstream fixes packaging.

## Verification

| Smoke | Result |
|---|---|
| 1 — imports + factory builds (dev box) | ✅ all three (`IncrementalTQCompressor`, `make_b_mse_hook`, `make_b_mse_hook_uniform`) build cleanly |
| 2 — env-var override (`TURBOQUANT_DEV_PATH=/Users/syn/synapticode/venv/src/turboquant`) | ✅ helper resolves via env-var |
| 3 — both candidates fail (env-var nonexistent + monkey-patched `__file__`) | ✅ helper raises `ImportError` with both candidate paths surfaced in diagnostic |
| 4 — fast tests (`pytest -m 'not slow'`) | ✅ 30/30 pass |
| 5 — slow tests (`pytest -m slow`) | ✅ 3/3 pass on dev box (no-hook MPS + with-hook CPU + R7-A FP16 baseline) |

## Skip-guard adjustment (test relocation)

`test_autoregressive_real_model_tinyllama_with_hook_cpu` had a skip-guard at the top doing `from tern_infer import make_b_mse_hook_uniform`. This fired too eagerly because `tools/` isn't on sys.path at test-collection time, causing the test to skip on dev boxes too. **Moved the skip-guard inside the test body** around the `tern_ppl_bench.build_kv_cache_hook(...)` call (which internally adds `tools/` to sys.path). Test now correctly:

- Passes on dev box (helper resolves turboquant via fallback)
- Skips on CI (helper raises `ImportError`; caught and converted to `pytest.skip`)

## CI behavior unchanged

This PR does **not** change CI test outcomes. The skip-guard semantics are preserved — `with_hook_cpu` continues to skip on CI runners that lack the canonical `../venv/src/turboquant` layout AND the `TURBOQUANT_DEV_PATH` env-var. CI environments would need turboquant provisioning (separate workstream) before this test could run on CI.

## Future workstream (not this PR)

When upstream turboquant lands `package_dir={"turboquant": "src"}, packages=["turboquant"]` in `setup.py` (or migrates to a pyproject.toml-based src layout), this helper can be removed and replaced with direct `from turboquant.cache import ...` imports across all consumer sites. Tracked as carry-forward in helper docstring.

## Cross-references

- PR #30 (merged today, commit `2a7e1b6`) — A' R7-B harness; CI escalation that motivated this fix
- PR #26 (merged today) — `make_b_mse_hook` factory (one of the three sites fixed)
- PR #27 (merged today) — `make_b_mse_hook_uniform` factory (one of the three sites fixed)
- PR #25 (merged earlier) — `IncrementalTQCompressor.__init__` site (third site fixed; missed in PR #30 carry-forward)

## Diff stats

`+67 / -18` lines across `tools/tern_infer.py` (+58 net) and `tests/test_ppl_bench_methodology.py` (+9 net).

## Test plan

- [x] All 30 fast tests pass
- [x] All 3 slow tests pass on dev box (including newly-passing `with_hook_cpu`)
- [x] Helper raises informative ImportError when both candidates fail
- [x] Helper accepts env-var override
- [x] All three call sites use the helper (no remaining hardcoded paths)
- [ ] CI passes (skip-guard preserves CI behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)