### PR TITLE
fix(tern_infer): factories return DynamicCache natively per R7-B §5.2

### DIFF
--- a/docs/wikitext2_ppl_methodology_autoregressive.md
+++ b/docs/wikitext2_ppl_methodology_autoregressive.md
@@ -163,8 +163,9 @@ def make_b_mse_hook(b_mse: int):
     """R12 compression hook factory."""
     def hook(past_kv):
         # Iterate (K, V) tensor pairs per layer; apply IncrementalTQCompressor
-        # at the configured b_mse parameter; return updated past_kv.
+        # at the configured b_mse parameter; wrap result in DynamicCache.
         ...
+        return DynamicCache(tuple(new_past))  # HF >= 5.x Cache contract
     return hook
 
 # Usage in R12 sweep:
@@ -174,7 +175,9 @@ for b_mse_value in [1, 2, 3, 4, 5, 6]:
     # record sum_loss / n per sweep point
 ```
 
-The hook receives the full `past_key_values` tuple-of-tuples (HF format: outer tuple over layers, inner tuple of (K, V)). The compression operator may mutate or replace tensors; the returned object must be a valid `past_key_values` for the next forward call.
+The hook receives `past_key_values` from the previous forward call and must return a `transformers.cache_utils.DynamicCache` instance compatible with HF transformers ≥5.x. This contract supersedes the legacy tuple-of-tuples format from HF transformers <5.x — the canonical R7-B harness path assumes Cache objects with `.get_seq_length()` per HF's evolved Cache interface.
+
+The factory builds its modified KV state internally (typically as a tuple-of-(K, V) sequence during construction for compatibility with the underlying turboquant primitives) and wraps the result in `DynamicCache(...)` before returning, providing a single canonical return shape across all R-track hook factories. Bench-harness code calling the hook receives the DynamicCache directly and passes it as-is to the next forward call; no shape bridging is required at the call site.
 
 *v1.1: a batched-uniform-precision variant `make_b_mse_hook_uniform` exists for sweep-time optimization; see §5.4 and R12 v1.1 §8.2.*
 
@@ -359,6 +362,17 @@ Per-model baselines are NOT optional: R12 cannot legitimately compute `ppl_headr
 ---
 
 ## §11 Change log
+
+### v1.1 §5.2 disambiguation (2026-05-17) — DynamicCache return contract specified
+
+In-place disambiguation under v1.1. Spec version stays at v1.1; schema version stays at `wikitext2_ppl_autoregressive/1.0`. No methodology change.
+
+§5.2 was ambiguous about hook return shape across HF transformers <5.x (legacy tuple-of-tuples) and ≥5.x (Cache objects). PR #26 and PR #27 factories returned legacy tuples; the bench harness in PR #30 bridged the gap via a defensive `DynamicCache(past_kv)` wrap with bare except for synthetic-stub tolerance. This disambiguation:
+
+- §5.2 now explicitly specifies the DynamicCache return contract per HF transformers ≥5.x
+- Both hook factories (`make_b_mse_hook`, `make_b_mse_hook_uniform`) wrap their internal tuple-of-(K, V) state in `DynamicCache(...)` at the return statement
+- The PR #30 harness shim is removed; the call site now assumes DynamicCache and passes through unchanged
+- Failure mode improves: a future hook bug returning a legacy tuple raises at the HF forward call with a specific Cache-shape error rather than being silently absorbed by the shim
 
 ### v1.0 → v1.1 cascade (2026-05-16) — hook lifetime + empirical cost expectations
 

--- a/tests/test_ppl_bench_methodology.py
+++ b/tests/test_ppl_bench_methodology.py
@@ -641,22 +641,16 @@ def test_evaluate_ppl_autoregressive_float64_accumulation():
 def test_evaluate_ppl_autoregressive_kv_cache_hook_returns_modified_kv():
     """§5.2 load-bearing semantic: subsequent forward MUST use hook's return value.
 
-    The hook returns a SimpleNamespace carrying a unique marker attribute and
-    a stub get_seq_length method (so the harness's DynamicCache compat shim
-    treats it as already-Cache-shaped and passes it through unchanged). The
-    stub model records what past_kv it received; the test asserts the marker
-    is present on subsequent forward calls — proving the hook's return value
-    reaches the next forward (not a stale closure-captured copy).
+    The hook returns a unique sentinel SimpleNamespace; if that sentinel reaches
+    the next forward call, the hook's return value is being consumed correctly
+    (rather than a stale closure-captured copy). The stub model records every
+    past_kv it receives, allowing direct assertion on identity.
     """
     model = _StubCausalLMAutoregressive()
     sequences = [[1, 2, 3, 4]]  # 3 forward calls; hook fires after each
 
     def modifying_hook(past_kv):
-        marker = SimpleNamespace(
-            __marker__="HOOK_MODIFIED",
-            get_seq_length=lambda: 0,  # satisfies harness DynamicCache shim
-        )
-        return marker
+        return SimpleNamespace(__marker__="HOOK_MODIFIED")
 
     tern_ppl_bench.evaluate_ppl_autoregressive(
         model=model, sequences=sequences, kv_cache_hook=modifying_hook,
@@ -671,6 +665,42 @@ def test_evaluate_ppl_autoregressive_kv_cache_hook_returns_modified_kv():
             f"§5.2: call {i} received {received!r}; "
             f"expected hook-modified SimpleNamespace with __marker__='HOOK_MODIFIED'"
         )
+
+
+def test_factory_returns_dynamic_cache_instance():
+    """R7-B v1.1 §5.2: kv_cache_hook factories must return DynamicCache instances.
+
+    Calls make_b_mse_hook_uniform (β1a, fast cold path) with a synthetic
+    past_kv and asserts the returned object is a transformers.cache_utils.DynamicCache
+    instance per the §5.2 return contract. Skips if turboquant is unavailable.
+    """
+    _infer_path = Path(__file__).resolve().parent.parent / "tools" / "tern_infer.py"
+    _infer_spec = importlib.util.spec_from_file_location("tern_infer", _infer_path)
+    assert _infer_spec is not None and _infer_spec.loader is not None
+    tern_infer = importlib.util.module_from_spec(_infer_spec)
+    _infer_spec.loader.exec_module(tern_infer)
+
+    from transformers.cache_utils import DynamicCache
+
+    try:
+        hook = tern_infer.make_b_mse_hook_uniform(
+            b_mse=4, n_layers=2, n_heads=4, head_dim=8, device="cpu"
+        )
+    except (ImportError, ModuleNotFoundError) as e:
+        pytest.skip(f"turboquant unavailable: {e}")
+
+    # Synthetic past_kv: tuple-of-(K, V) tensor pairs, shape per factory contract.
+    synthetic_past_kv = tuple(
+        (
+            torch.randn(1, 4, 4, 8, dtype=torch.float32),
+            torch.randn(1, 4, 4, 8, dtype=torch.float32),
+        )
+        for _ in range(2)
+    )
+    result = hook(synthetic_past_kv)
+    assert isinstance(result, DynamicCache), (
+        f"§5.2: factory must return DynamicCache; got {type(result).__name__}"
+    )
 
 
 # ── R7-B §7 — output schema ────────────────────────────────────────────

--- a/tools/tern_infer.py
+++ b/tools/tern_infer.py
@@ -24,6 +24,7 @@ from pathlib import Path
 from typing import Optional
 
 import torch
+from transformers.cache_utils import DynamicCache
 
 # Ensure tern-core is importable
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
@@ -348,7 +349,7 @@ def make_b_mse_hook(
                 new_k[:, head_idx] = k_recon.reshape(batch, seq_len, hd).to(k.dtype)
                 new_v[:, head_idx] = v_recon.reshape(batch, seq_len, hd).to(v.dtype)
             new_past.append((new_k, new_v))
-        return tuple(new_past)
+        return DynamicCache(tuple(new_past))
 
     return hook
 
@@ -502,11 +503,11 @@ def make_b_mse_hook_uniform(
         k_out_all = k_recon.reshape(n_layers, n_heads, batch, seq_len, d).permute(0, 2, 1, 3, 4)
         v_out_all = v_recon.reshape(n_layers, n_heads, batch, seq_len, d).permute(0, 2, 1, 3, 4)
 
-        return tuple(
+        return DynamicCache(tuple(
             (k_out_all[l].contiguous().to(kv_pairs[l][0].dtype),
              v_out_all[l].contiguous().to(kv_pairs[l][1].dtype))
             for l in range(n_layers)
-        )
+        ))
 
     return hook
 

--- a/tools/tern_ppl_bench.py
+++ b/tools/tern_ppl_bench.py
@@ -323,25 +323,11 @@ def evaluate_ppl_autoregressive(
                     use_cache=True,
                 )
                 past_kv = outputs.past_key_values
+                # Per R7-B v1.1 §5.2: kv_cache_hook returns DynamicCache
+                # directly. The legacy-tuple wrapping bridge from PR #30 is
+                # removed; the hook factories (PR #26, PR #27) now produce
+                # Cache-shaped objects natively.
                 past_kv = kv_cache_hook(past_kv)
-                # HF Cache-shape shim: PR #26 / PR #27 hooks return legacy
-                # tuple-of-tuples per R7-B v1.1 §5.2 docstring; current HF
-                # transformers (>= 5.x) requires Cache objects with
-                # .get_seq_length() at modeling_<arch>.py forward path.
-                # Bridge the spec's "return past_key_values" contract with
-                # HF's evolving shape via DynamicCache wrap when needed.
-                if past_kv is not None and not hasattr(past_kv, "get_seq_length"):
-                    try:
-                        from transformers.cache_utils import DynamicCache
-
-                        past_kv = DynamicCache(past_kv)
-                    except (ImportError, AttributeError, TypeError, ValueError):
-                        # Older transformers may accept tuple natively; or
-                        # synthetic-stub tests may pass non-tensor markers
-                        # that DynamicCache cannot validate. Pass through —
-                        # the next forward call will either accept or raise
-                        # meaningfully against its own expectations.
-                        pass
 
                 logits = outputs.logits[0, -1]
                 target = torch.tensor(seq[t + 1], device=device)


### PR DESCRIPTION
## Summary

Disambiguates R7-B v1.1 §5.2 hook return contract: factories return `DynamicCache` natively per HF transformers ≥5.x; PR #30's harness shim removed once factories are Cache-shaped at source.

## Why

Yesterday's MPS validation surfaced the contract ambiguity:

- PR #26 / PR #27 hook factories returned legacy tuple-of-tuples
- HF transformers ≥5.x forward path requires `Cache` objects with `.get_seq_length()`
- PR #30 bridged the gap via a defensive `DynamicCache(past_kv)` wrap with bare-except for synthetic-stub tolerance
- Spec docstring §5.2 said "hook returns past_key_values" — ambiguous across HF <5.x (tuple) and ≥5.x (Cache)

The harness shim was load-bearing only as a bridge. With factories now wrapping at the return statement, the bridge purpose dissolves and the shim is removed.

## Changes

- **`tools/tern_infer.py`** — both `make_b_mse_hook` and `make_b_mse_hook_uniform` wrap their internal tuple-of-(K, V) state in `DynamicCache(...)` at the return statement. Module-level `from transformers.cache_utils import DynamicCache` added.
- **`tools/tern_ppl_bench.py`** — PR #30 harness shim block (15 lines) removed from `evaluate_ppl_autoregressive`. Brief comment at the call site notes the contract source.
- **`docs/wikitext2_ppl_methodology_autoregressive.md`** — §5.2 amended to explicitly specify the `transformers.cache_utils.DynamicCache` return contract. Pseudocode example shows the wrap. §11 change log entry records the v1.1 §5.2 disambiguation.
- **`tests/test_ppl_bench_methodology.py`** — new `test_factory_returns_dynamic_cache_instance` pins the contract via `isinstance(...)` on the β1a fast factory; skips when turboquant unavailable. Existing `test_evaluate_ppl_autoregressive_kv_cache_hook_returns_modified_kv` simplified: removed vestigial `get_seq_length=lambda: 0` shim accommodation; docstring rewritten to reflect the test's actual intent (verify hook return reaches next forward).

## Methodology version note

This is a **§5.2 docstring disambiguation**, not a methodology shift. Spec version stays at v1.1; schema version stays at `wikitext2_ppl_autoregressive/1.0`. A separate D2 amendment workstream will bump to v1.2 for the §1.1 calibration-gate widening — out of scope here.

## Contract failure mode improvement

Before: a future hook bug returning a legacy tuple would be silently absorbed by the shim's bare-except.
After: such a bug raises at the HF forward call with a specific Cache-shape error, diagnosable from the traceback.

## Test plan

- [x] `test_factory_returns_dynamic_cache_instance` (new) — `isinstance(hook(synthetic_past_kv), DynamicCache)` PASS
- [x] 31/31 fast tests pass (`pytest tests/test_ppl_bench_methodology.py -m 'not slow'`)
- [x] 3/3 slow tests pass (`pytest tests/test_ppl_bench_methodology.py -m slow`) — including real-model TinyLlama hook+CPU integration
- [x] CLI smoke (`tools/tern_ppl_bench.py --methodology autoregressive --kv-cache-hook uniform --b-mse 4 --device cpu` on TinyLlama, N=1, L=64): finite PPL, schema-conformant JSON written

## Cross-references

- R7-B v1.1 §5.2 (PR #29 — original methodology landing)
- `make_b_mse_hook` (PR #26)
- `make_b_mse_hook_uniform` (PR #27)
- Harness shim origin (PR #30 — bridged the contract gap; this PR removes it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)