### PR TITLE
docs(r7-b): v1.2 calibration gate widening per D1 factor decomposition

### DIFF
--- a/docs/wikitext2_ppl_methodology_autoregressive.md
+++ b/docs/wikitext2_ppl_methodology_autoregressive.md
@@ -1,6 +1,6 @@
-# WikiText-2 Autoregressive PPL Methodology — R7-B v1.0
+# WikiText-2 Autoregressive PPL Methodology — R7-B v1.2
 
-**Document status:** Canonical (v1.0)
+**Document status:** Canonical (v1.2)
 **Authored:** 2026-05-15
 **Repository path:** `tern-core/docs/wikitext2_ppl_methodology_autoregressive.md`
 **Companion documents:**
@@ -25,11 +25,29 @@ R7-B v1.0 is the **autoregressive sibling** to R7-A v1.0's teacher-forcing metho
 
 R7-B's purpose is to provide R12 with a methodologically-sound measurement hook: a procedure where KV-cache values exist as accumulating intermediate state across forward calls, and where compression of that cache is observable via PPL degradation. R7-A's teacher-forcing methodology cannot serve this purpose — its forward passes do not retain inter-call KV state, so KV-cache compression has nothing to corrupt.
 
-### §1.1 The methodology invariant
+### §1.1 R7-A reference equivalence (calibration gate)
 
-**Under no KV-cache compression, R7-B and R7-A must produce equivalent PPL on the same model** (modulo float-precision differences between accumulated-cache attention and single-pass attention, expected <0.5%).
+Under no compression on TinyLlama-1.1B, R7-B baseline PPL must satisfy the N-indexed calibration gate below, derived empirically per §11's v1.2 amendment factor decomposition:
 
-This invariant is the calibration gate: R7-B v1.0 first execution on TinyLlama-1.1B FP16 must produce baseline PPL within 0.5% of the R7-A v1.0 cached baseline (`8.0307`, run_id `20260514T031257Z`, commit `77532e8`). Material deviation flags an implementation bug — typically position-embedding mismatch, BOS handling, or attention-mask logic in the token-by-token loop.
+| N (sequences) | Calibration gate |
+|---|---|
+| 16 | ≤ 1.68% |
+| 32 | ≤ 1.38% |
+| 64 | ≤ 1.17% |
+| 128 | ≤ 1.02% |
+| 256 | ≤ 0.91% |
+
+The gate widens with smaller N to accommodate sampling noise (scaling as 1/√N from empirical σ ≈ 0.513% at N=16 measured on TinyLlama-1.1B) and the structural F1 contribution (R7-B BOS-per-sequence design advantage over R7-A's sliding-window cold-context early positions, ≈ 0.66% persistent across N).
+
+Interpolation formula for intermediate N:
+
+> |Δ| < |F1| + 2σ(N) where F1 ≈ 0.66% and σ(N) = σ(16) × √(16/N), σ(16) ≈ 0.513%
+
+For N ≥ 16, R7-B baselines passing this gate are considered methodologically calibrated against R7-A for the purpose of downstream R12 KV-cache compression headroom measurements.
+
+**R7-A reference baseline:** PPL=`8.0307`, run_id `20260514T031257Z`, commit `77532e8` (R7-A v1.0 cached).
+
+*v1.0 → v1.1: gate was <0.5% under the (empirically falsified) assumption that R7-B and R7-A converge to within fp16 numerical noise under no compression. v1.2 corrects this with the N-indexed table above; see §11 for the empirical factor decomposition.*
 
 ### §1.2 Distinction from the 12 May TQ bench PPL anchor
 
@@ -152,7 +170,7 @@ For N=16 sequences of L=2048 with BOS prepended, total `num_scored = 16 × 2048 
 
 The model receives ONLY the single new token per forward call. The KV cache holds all prior positions. This is mechanically identical to how transformers autoregressively generate at inference time — the difference is we provide the next "generated" token from the corpus (teacher-forcing in spirit) rather than sampling from the logits.
 
-This contrasts with R7-A, which feeds the entire window's tokens in one forward call and uses a causal-mask-aware single-pass attention. R7-A's single-pass attention computes K and V for all positions in one matrix multiply; R7-B's accumulating cache builds K and V position-by-position. Under no compression, the resulting attention output should be numerically identical modulo float-rounding (typically <0.01% per-token loss difference; <0.5% aggregate PPL difference).
+This contrasts with R7-A, which feeds the entire window's tokens in one forward call and uses a causal-mask-aware single-pass attention. R7-A's single-pass attention computes K and V for all positions in one matrix multiply; R7-B's accumulating cache builds K and V position-by-position. Under no compression, the resulting attention output should be numerically identical modulo float-rounding (typically <0.01% per-token loss difference at the per-token level). Per §1.1 calibration gate and §11 factor decomposition, aggregate PPL difference between R7-A and R7-B under no compression decomposes into three independent factors: F1 (structural ≈ 0.66%, persistent across N), F2 (sampling noise σ ≈ 0.513% at N=16, scaling as 1/√N), and F3 (FP16 vs FP32 numerical, empirically negligible at ≈ 0.003%). The aggregate calibration gate is N-indexed per §1.1.
 
 ### §5.2 KV cache compression injection (R12 hook)
 
@@ -229,7 +247,7 @@ R7-B emits per-run JSON conformant to `wikitext2_ppl_autoregressive/1.0`:
   "run_id": "string (timestamp ISO 8601 compact, e.g. 20260515T091500Z)",
   "tern_core_version": "string",
   "tern_core_git_commit": "string (10-char sha)",
-  "spec_version": "wikitext2_ppl_methodology_autoregressive v1.0",
+  "spec_version": "wikitext2_ppl_methodology_autoregressive v1.2",
 
   "model": {
     "model_id": "string (HF model_id or local path)",
@@ -320,7 +338,7 @@ seed: 1337  # for any tiebreak determinism; sequence selection is sequential, no
 
 **Acceptance gates:**
 
-1. **§1.1 invariant**: produced `ppl_autoregressive` must be within 0.5% of R7-A v1.0 cached baseline (`8.0307`). I.e., result MUST be in `[7.99, 8.07]`. Outside this range = methodology bug, halt and surface.
+1. **§1.1 invariant**: produced `ppl_autoregressive` must satisfy the §1.1 N-indexed calibration gate at the run's N. For the canonical N=16 first execution, this means within 1.68% of R7-A baseline (PPL=`8.0307`), i.e. result MUST be in `[7.896, 8.166]`. For larger N, see §1.1 for tighter bounds. Outside the gate at the run's N = methodology bug or excessive sampling noise; halt and surface for factor attribution per §11.
 2. Schema conformance: output JSON validates against `wikitext2_ppl_autoregressive/1.0`
 3. Reproducibility: bit-identical PPL on second run (deterministic sequence selection + deterministic forward passes)
 4. Wall-clock: should be 25-40 min on M4 Pro MPS. >60 min flags performance regression worth investigating.
@@ -363,6 +381,32 @@ Per-model baselines are NOT optional: R12 cannot legitimately compute `ppl_headr
 
 ## §11 Change log
 
+### v1.1 → v1.2 cascade (2026-05-17) — calibration gate widening per D1 factor decomposition
+
+Cascade applied 2026-05-17 per surgeon ratification. Sourced from R-track session 2026-05-16 to 2026-05-17: B baseline measurement (R7-B @ N=16 FP16, PPL=7.9367) revealed the v1.1 §1.1 gate of <0.5% was structurally infeasible. D1 slim reconnaissance (D1.A: R7-B @ N=64 FP16; D1.B: R7-B @ N=16 FP32) provided empirical factor decomposition of the -1.171% B-vs-R7-A delta:
+
+| Factor | Description | Contribution | Confidence |
+|---|---|---|---|
+| F1 | R7-B BOS-per-sequence structural advantage over R7-A sliding-window cold-context early positions | -0.655% | HIGH (two-path cross-check; agreement to 0.006%) |
+| F2 | Sampling noise at N=16 (σ ≈ 0.513%, 1/√N scaling) | -0.513% | MEDIUM (single-shot; bootstrap would refine) |
+| F3 | FP16 vs FP32 numerical noise | -0.003% | HIGH (direct measurement, same N/methodology, dtype only) |
+| **Sum** | | **-1.171%** | (exact, residual 0.000%) |
+
+**v1.1 §1.1 gate post-mortem:** the <0.5% gate was structurally infeasible — F1 alone consumes 0.66% before any sampling variation. The implicit assumption that R7-B and R7-A converge under no compression is falsified by R7-B §4's BOS-per-sequence design, which systematically advantages R7-B by avoiding the cold-context early-window penalty inherent to R7-A's sliding windows. R7-B is not slightly less rigorous than R7-A; R7-B is slightly *more* rigorous by eliminating a known artifact.
+
+**v1.2 widening:** the calibration gate widens to the N-indexed table per §1.1, derived from |Δ| < |F1| + 2σ(N). Methodologists running R7-B at larger N earn tighter calibration tolerance — at N=256, the gate tightens to ≤0.91% while still budgeting 2σ sampling envelope. The methodology becomes more rigorous as N grows, providing a clear cost-benefit tradeoff: compute investment → calibration precision.
+
+**Methodology amendment workflow precedent:** the D1 reconnaissance → factor decomposition table → v1.2 amendment workflow is a reproducible idiom for future R-track methodology gate failures: don't just widen the gate to accommodate empirical results; decompose the failure into independent factors via targeted measurements, then ground the amendment in empirics rather than rounding to convenient thresholds.
+
+**Cross-references:**
+- B baseline measurement: 2026-05-16, R7-B @ N=16 FP16 MPS, PPL=7.9367, run_id=20260516T065626Z
+- D1.A: 2026-05-17, R7-B @ N=64 FP16 MPS, PPL=7.9776
+- D1.B: 2026-05-17, R7-B @ N=16 FP32 MPS, PPL=7.9365
+- R7-A baseline reference: run_id=20260514T031257Z, PPL=8.0307
+- Companion v1.1 disambiguation: PR #32 (§5.2 DynamicCache contract; not a methodology change, in-place clarification under v1.1)
+
+No schema changes; `wikitext2_ppl_autoregressive/1.0` remains stable.
+
 ### v1.1 §5.2 disambiguation (2026-05-17) — DynamicCache return contract specified
 
 In-place disambiguation under v1.1. Spec version stays at v1.1; schema version stays at `wikitext2_ppl_autoregressive/1.0`. No methodology change.
@@ -397,4 +441,4 @@ Pre-empirical wall-time projections in methodology specs are aspirational, not a
 
 ---
 
-*Ratified 2026-05-16 — tern-core canonical methodology document, R7-B v1.1. Autoregressive sibling to R7-A v1.0; consumed by R12 v1.1 KV-cache-compression PPL diagnostic. The §1.1 invariant (R7-B baseline ≈ R7-A baseline within 0.5% under no compression) is the methodology's calibration gate. v1.1 surfaces hook-factory lifetime + empirical per-call cost expectations (see §5.4); inherits R12 v1.1's banked lesson on pre-empirical wall-time projections.*
+*Ratified 2026-05-17 — tern-core canonical methodology document, R7-B v1.2. Autoregressive sibling to R7-A v1.0; consumed by R12 v1.1 KV-cache-compression PPL diagnostic. The §1.1 invariant (R7-B baseline calibration against R7-A reference per the N-indexed gate table) is the methodology's calibration gate. v1.1 surfaces hook-factory lifetime + empirical per-call cost expectations (see §5.4); inherits R12 v1.1's banked lesson on pre-empirical wall-time projections. v1.2 widens the §1.1 calibration gate to an N-indexed table per empirical factor decomposition (F1 structural ≈0.66%, F2 sampling noise σ(N), F3 FP precision negligible); see §11 for the empirical narrative.*

--- a/tools/tern_ppl_bench.py
+++ b/tools/tern_ppl_bench.py
@@ -58,10 +58,10 @@ DEFAULT_SEQ_LEN = 2048
 DEFAULT_STRIDE = 2048
 DEFAULT_ROLLING_STRIDE = 1024  # R7-A §5 diagnostic rolling-window variant
 
-# ── R7-B v1.1 §7 schema constants ──────────────────────────────────────
+# ── R7-B v1.2 §7 schema constants ──────────────────────────────────────
 
 SCHEMA_VERSION_AR = "wikitext2_ppl_autoregressive/1.0"
-SPEC_VERSION_AR = "wikitext2_ppl_methodology_autoregressive v1.1"
+SPEC_VERSION_AR = "wikitext2_ppl_methodology_autoregressive v1.2"
 DEFAULT_NUM_SEQUENCES = 16   # R7-B v1.0 §4 canonical N
 DEFAULT_AR_SEQ_LEN = 2048    # R7-B v1.0 §4 canonical L (matches R7-A seq_len)
 
@@ -922,7 +922,7 @@ def main() -> None:
             / "wikitext2_ppl_autoregressive"
         )
 
-    methodology_tag = "R7-A v1.0" if methodology == "sliding" else "R7-B v1.1"
+    methodology_tag = "R7-A v1.0" if methodology == "sliding" else "R7-B v1.2"
     print(f"[tern_ppl_bench] {methodology_tag} — variant={variant}")
     t_load = time.perf_counter()
 
@@ -1041,7 +1041,7 @@ def main() -> None:
     # ── R7-B v1.1 §5 autoregressive eval ────────────────────────────
     print(
         f"[tern_ppl_bench]   eval: N={args.num_sequences}, L={args.ar_seq_len} "
-        f"(R7-B v1.1 §4 — non-overlapping, BOS-per-sequence={bos_prepended})"
+        f"(R7-B v1.2 §4 — non-overlapping, BOS-per-sequence={bos_prepended})"
     )
     sequences = build_sequences_autoregressive(
         tokens=tokens,


### PR DESCRIPTION
## Summary

R7-B v1.2 amendment widening the §1.1 calibration gate from <0.5% (structurally infeasible per D1 reconnaissance) to an N-indexed table per `|Δ| < |F1| + 2σ(N)`. Doc-consistency sweep folds 4 lagging items + 3 log/comment version stamps into the same PR rather than splitting.

## Why

This morning's D1 reconnaissance (R7-B@N=64 FP16 + R7-B@N=16 FP32, sequential MPS) decomposed the −1.171% B-vs-R7-A delta into three independent factors:

| Factor | Description | Contribution | Confidence |
|---|---|---|---|
| F1 | R7-B BOS-per-sequence structural advantage over R7-A sliding-window cold-context early positions | −0.655% | HIGH (two-path cross-check; agreement to 0.006%) |
| F2 | Sampling noise at N=16 (σ ≈ 0.513%, 1/√N scaling) | −0.513% | MEDIUM (single-shot; bootstrap would refine) |
| F3 | FP16 vs FP32 numerical noise | −0.003% | HIGH (direct measurement, dtype only) |
| **Sum** | | **−1.171%** | (exact, residual 0.000%) |

The v1.1 <0.5% gate was structurally infeasible: **F1 alone consumes 0.66%** before any sampling variation. R7-B is not slightly less rigorous than R7-A; R7-B is slightly *more* rigorous by eliminating R7-A's cold-context early-window artefact.

## v1.2 N-indexed gate table (per §1.1)

| N | Gate |
|---|---|
| 16 | ≤ 1.68% |
| 32 | ≤ 1.38% |
| 64 | ≤ 1.17% |
| 128 | ≤ 1.02% |
| 256 | ≤ 0.91% |

Interpolation: `|Δ| < |F1| + 2σ(N)` where F1 ≈ 0.66% and σ(N) = σ(16) × √(16/N), σ(16) ≈ 0.513%.

Methodologists running R7-B at larger N earn tighter calibration tolerance — at N=256, gate tightens to ≤0.91% while still budgeting 2σ sampling envelope.

## Changes

### Primary amendment (briefing D.1–D.5)
- **`docs/.../wikitext2_ppl_methodology_autoregressive.md`** §1.1 — header reframed "The methodology invariant" → "R7-A reference equivalence (calibration gate)"; new N-indexed table + interpolation formula; R7-A baseline reference preserved
- §5.1 — last sentence rewritten to reference §1.1 + §11 factor decomposition (no longer asserts <0.5% aggregate)
- §11 — new top entry `### v1.1 → v1.2 cascade (2026-05-17) — calibration gate widening per D1 factor decomposition` above the v1.1 §5.2 disambiguation entry
- **`tools/tern_ppl_bench.py`** SPEC_VERSION_AR constant `v1.1` → `v1.2`

### Doc-consistency sweep (Phase B dispositions, ratified)
- Front matter: title + Document status both bumped v1.0 → v1.2 directly (folds the v1.1 hygiene lag from yesterday's cascade into this PR)
- §7 schema example JSON: `spec_version` example string bumped v1.0 → v1.2
- Footer: `Ratified 2026-05-16 — R7-B v1.1` → `Ratified 2026-05-17 — R7-B v1.2`; "within 0.5%" framing replaced with N-indexed gate reference; new sentence summarising v1.2 widening parallel to the existing v1.1 lessons-learned line
- §8 acceptance gate: `[7.99, 8.07]` hardcoded band rewritten to reference §1.1 (`[7.896, 8.166]` at canonical N=16, with "see §1.1 for tighter bounds at larger N") so future §1.1 amendments propagate automatically

### Additional live-version-label bumps (discovered Phase E)
- `tools/tern_ppl_bench.py` line 61 comment header `R7-B v1.1 §7 schema constants` → `v1.2`
- line 925 `methodology_tag = "R7-B v1.1"` → `"R7-B v1.2"` (CLI log decoration)
- line 1044 eval log message `(R7-B v1.1 §4 …)` → `(R7-B v1.2 §4 …)`

Historical "v1.0 §4 canonical N/L" / "v1.1 §5 introduced" anchors retained as historically accurate per the briefing's disposition lean.

## Methodology version note

**Spec version:** v1.1 → v1.2 (calibration gate widening, doc-consistency)  
**Schema version:** `wikitext2_ppl_autoregressive/1.0` — unchanged (data format identical; gate widening is methodology, not data)  
**No methodology code changes** — documentation amendment + constant + log strings only.

## Test plan

- [x] 31/31 fast tests pass (`pytest tests/test_ppl_bench_methodology.py -m 'not slow'`)
- [x] 3/3 slow tests pass (`pytest tests/test_ppl_bench_methodology.py -m slow`) — real-model TinyLlama
- [x] CLI smoke produces `spec_version: wikitext2_ppl_methodology_autoregressive v1.2` in fresh output JSON; schema_version unchanged
- [x] Doc consistency sweep: all live `<0.5%` gate assertions removed; remaining `<0.5%` mentions are historical (v1.0→v1.1 footnote, §11 post-mortem)
- [x] §1.1 ↔ §8 mutual consistency: §8 references §1.1 N-indexed gate without restating bare percentages
- [x] Footer matches §1.1 framing: N-indexed gate reference, no bare-percentage residuals

## Cross-references

- **D1 reconnaissance** (2026-05-17 R-track session):
  - D1.A: R7-B @ N=64 FP16 MPS, PPL=7.9776 (54.8 min)
  - D1.B: R7-B @ N=16 FP32 MPS, PPL=7.9365 (17.8 min)
- **B baseline** (2026-05-16): run_id=20260516T065626Z, R7-B @ N=16 FP16, PPL=7.9367
- **R7-A reference**: run_id=20260514T031257Z, PPL=8.0307
- **Companion v1.1 disambiguation:** PR #32 (§5.2 DynamicCache contract; in-place v1.1 clarification, not a methodology change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)