### PR TITLE
feat(r12): per-point process-split orchestrator (libdispatch-trap mitigation)

### DIFF
--- a/tests/test_r12_sweep_aggregate.py
+++ b/tests/test_r12_sweep_aggregate.py
@@ -1,0 +1,302 @@
+"""Unit tests for tern_r12_sweep_aggregate.
+
+Aggregator is a pure function over per-point JSONs in a sweep directory.
+Tests use fixture per-point JSON dicts written to tmp_path; no real subprocess
+invocation, no model load.
+
+Coverage:
+  - happy path: 6-point grid → grid_exhausted termination
+  - ceiling_crossed: terminated_at_ceiling=True on point 3 → halt
+  - hook_construction_failure: hook_construction_failed=True on point 1
+  - ppl_eval_failure: ppl_kv_compressed=None without hook_construction_failed
+  - incomplete: 3 points present, 6-point grid expected → 'incomplete'
+  - recommended_operating_point selection: minimum b_mse under calibration gate
+  - recommended_operating_point null-stub: no qualifying points
+  - point ordering: out-of-order JSON filenames re-sort by point_index
+
+Copyright (c) 2025-2026 Gamma Seeds Pte Ltd. All rights reserved.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+# Ensure tools/ on path
+TOOLS = Path(__file__).resolve().parent.parent / "tools"
+sys.path.insert(0, str(TOOLS))
+
+import tern_r12_sweep_aggregate as agg  # noqa: E402
+
+
+# ── Fixture helpers ────────────────────────────────────────────────────────
+
+
+def _make_point_json(
+    *,
+    point_index: int,
+    b_mse: int,
+    diagnostic_run_id: str = "deadbeef-1234-5678-9abc-def012345678",
+    ppl_kv_compressed: float | None = 8.0,
+    ppl_headroom: float | None = 0.005,
+    ppl_headroom_band: str | None = "Excellent",
+    terminated_at_ceiling: bool = False,
+    hook_construction_failed: bool = False,
+    notes: str = "test fixture",
+    model_id: str = "test/tinyllama",
+    num_sequences: int = 16,
+    seq_len: int = 2048,
+) -> dict:
+    return {
+        "schema_version": "ppl_headroom_kv_cache_point/1.0",
+        "diagnostic_run_id": diagnostic_run_id,
+        "point_index": point_index,
+        "config": {
+            "b_mse": b_mse,
+            "weight_threshold": "FP16",
+            "kv_hook_application_scope": "all_layers",
+            "num_sequences": num_sequences,
+            "seq_len": seq_len,
+            "model_id": model_id,
+        },
+        "ppl_eval_run_id": f"20260518T00000{point_index}Z",
+        "baseline_ppl_r7b": 7.9367,
+        "ppl_kv_compressed": ppl_kv_compressed,
+        "ppl_headroom": ppl_headroom,
+        "ppl_headroom_band": ppl_headroom_band,
+        "kv_cache_compression_ratio": 16.0 / b_mse,
+        "terminated_at_ceiling": terminated_at_ceiling,
+        "hook_construction_failed": hook_construction_failed,
+        "notes": notes,
+    }
+
+
+def _write_point(sweep_dir: Path, payload: dict) -> Path:
+    idx = payload["point_index"]
+    b = payload["config"]["b_mse"]
+    runid = payload["ppl_eval_run_id"]
+    fn = sweep_dir / f"point_{idx:02d}_b_mse_{b}_{runid}.json"
+    fn.write_text(json.dumps(payload, indent=2) + "\n")
+    return fn
+
+
+def _default_inputs(b_mse_grid: list[int]) -> dict:
+    return {
+        "source_model": "test/tinyllama",
+        "baseline_ppl_r7b": 7.9367,
+        "baseline_run_id": "test-baseline-runid",
+        "ppl_headroom_ceiling": 1.0,
+        "sweep_grid": {"b_mse": b_mse_grid},
+        "num_sequences": 16,
+        "seq_len": 2048,
+        "seed": 1337,
+        "continue_past_ceiling": False,
+    }
+
+
+def _aggregate(
+    sweep_dir: Path,
+    b_mse_grid: list[int],
+    *,
+    continue_past_ceiling: bool = False,
+) -> dict:
+    manifest_path = agg.aggregate_sweep_directory(
+        sweep_dir=sweep_dir,
+        diagnostic_run_id="deadbeef-1234-5678-9abc-def012345678",
+        inputs=_default_inputs(b_mse_grid),
+        calibration_gate_pct=1.68,
+        device="mps",
+        notes="test",
+        total_eval_wall_time_seconds=42.0,
+        expected_b_mse_grid=b_mse_grid,
+        continue_past_ceiling=continue_past_ceiling,
+    )
+    return json.loads(manifest_path.read_text())
+
+
+# ── Tests ──────────────────────────────────────────────────────────────────
+
+
+def test_happy_path_grid_exhausted(tmp_path: Path) -> None:
+    """6-point clean grid → grid_exhausted; recommended = lowest b_mse under gate."""
+    grid = [6, 5, 4, 3, 2, 1]
+    for idx, b in enumerate(grid):
+        # ppl_headroom = 0.005 = 0.5% — under 1.68% gate
+        _write_point(tmp_path, _make_point_json(point_index=idx, b_mse=b))
+
+    manifest = _aggregate(tmp_path, grid)
+
+    assert manifest["schema_version"] == "ppl_headroom_kv_cache_sweep/1.0"
+    assert manifest["termination"]["terminated_reason"] == "grid_exhausted"
+    assert manifest["termination"]["terminated_at_point_index"] is None
+    assert len(manifest["points"]) == 6
+    assert len(manifest["frontier"]) == 6
+    rec = manifest["recommended_operating_point"]
+    assert rec["b_mse"] == 1  # lowest qualifying b_mse
+    assert manifest["hardware"]["ppl_eval_wall_time_seconds"] == 42.0
+
+
+def test_ceiling_crossed_halt(tmp_path: Path) -> None:
+    """terminated_at_ceiling on point 3 → ceiling_crossed termination."""
+    points = [
+        _make_point_json(point_index=0, b_mse=6),
+        _make_point_json(point_index=1, b_mse=5),
+        _make_point_json(point_index=2, b_mse=4),
+        _make_point_json(point_index=3, b_mse=3, terminated_at_ceiling=True,
+                         ppl_kv_compressed=16.0, ppl_headroom=1.5,
+                         ppl_headroom_band="Fail"),
+    ]
+    for p in points:
+        _write_point(tmp_path, p)
+
+    manifest = _aggregate(tmp_path, [6, 5, 4, 3, 2, 1])
+    # incomplete grid (4 of 6) but ceiling_crossed is the explicit halt
+    # cause and takes precedence over missing-points inference.
+    assert manifest["termination"]["terminated_reason"] == "ceiling_crossed"
+    assert manifest["termination"]["terminated_at_point_index"] == 3
+    assert manifest["termination"]["failed_at_b_mse"] == 3
+
+
+def test_ceiling_crossed_continues_when_flag_set(tmp_path: Path) -> None:
+    """With continue_past_ceiling=True, ceiling_crossed does NOT halt."""
+    points = [
+        _make_point_json(point_index=0, b_mse=4),
+        _make_point_json(point_index=1, b_mse=2, terminated_at_ceiling=True,
+                         ppl_kv_compressed=16.0, ppl_headroom=1.5,
+                         ppl_headroom_band="Fail"),
+    ]
+    for p in points:
+        _write_point(tmp_path, p)
+
+    manifest = _aggregate(tmp_path, [4, 2], continue_past_ceiling=True)
+    assert manifest["termination"]["terminated_reason"] == "grid_exhausted"
+
+
+def test_hook_construction_failure(tmp_path: Path) -> None:
+    """hook_construction_failed=True → hook_construction_failure termination."""
+    points = [
+        _make_point_json(point_index=0, b_mse=6),
+        _make_point_json(
+            point_index=1, b_mse=5,
+            ppl_kv_compressed=None, ppl_headroom=None, ppl_headroom_band=None,
+            hook_construction_failed=True,
+        ),
+    ]
+    for p in points:
+        _write_point(tmp_path, p)
+
+    manifest = _aggregate(tmp_path, [6, 5, 4, 3, 2, 1])
+    assert manifest["termination"]["terminated_reason"] == "hook_construction_failure"
+    assert manifest["termination"]["terminated_at_point_index"] == 1
+    assert manifest["termination"]["failed_at_b_mse"] == 5
+
+
+def test_ppl_eval_failure(tmp_path: Path) -> None:
+    """ppl_kv_compressed=None without hook_construction_failed → ppl_eval_failure.
+
+    Sweep continued past the failure point (less-aggressive b_mse may succeed),
+    so all 6 points are present on disk.
+    """
+    grid = [6, 5, 4, 3, 2, 1]
+    for idx, b in enumerate(grid):
+        if b == 3:
+            _write_point(tmp_path, _make_point_json(
+                point_index=idx, b_mse=b,
+                ppl_kv_compressed=None, ppl_headroom=None, ppl_headroom_band=None,
+            ))
+        else:
+            _write_point(tmp_path, _make_point_json(point_index=idx, b_mse=b))
+
+    manifest = _aggregate(tmp_path, grid)
+    assert manifest["termination"]["terminated_reason"] == "ppl_eval_failure"
+    assert manifest["termination"]["failed_at_b_mse"] == 3
+
+
+def test_incomplete_subprocess_death(tmp_path: Path) -> None:
+    """3 points present, 6 expected, no halt-marker → 'incomplete' termination.
+
+    Simulates the libdispatch-trap failure mode: subprocess killed by OS
+    before a halt-marker (ceiling/hook-fail) was reached.
+    """
+    grid = [6, 5, 4, 3, 2, 1]
+    for idx in range(3):
+        _write_point(tmp_path, _make_point_json(
+            point_index=idx, b_mse=grid[idx],
+        ))
+
+    manifest = _aggregate(tmp_path, grid)
+    assert manifest["termination"]["terminated_reason"] == "incomplete"
+    assert manifest["termination"]["terminated_at_point_index"] == 2
+    assert manifest["termination"]["failed_at_b_mse"] == 4
+
+
+def test_recommended_operating_point_null_when_no_qualifier(tmp_path: Path) -> None:
+    """All points outside calibration gate → null-stub recommended_operating_point."""
+    # ppl_headroom = 0.05 = 5% (above 1.68% gate)
+    for idx, b in enumerate([6, 5, 4]):
+        _write_point(tmp_path, _make_point_json(
+            point_index=idx, b_mse=b, ppl_headroom=0.05,
+            ppl_headroom_band="Marginal",
+        ))
+
+    manifest = _aggregate(tmp_path, [6, 5, 4])
+    rec = manifest["recommended_operating_point"]
+    assert rec["b_mse"] is None
+    assert rec["point_index"] is None
+    assert "no sweep point" in rec["rationale"]
+
+
+def test_point_ordering_by_point_index(tmp_path: Path) -> None:
+    """Files written out of order → manifest points sorted by point_index."""
+    # Write in reverse order
+    for idx, b in [(2, 4), (0, 6), (1, 5)]:
+        _write_point(tmp_path, _make_point_json(point_index=idx, b_mse=b))
+
+    manifest = _aggregate(tmp_path, [6, 5, 4])
+    indices = [pt["point_index"] for pt in manifest["points"]]
+    assert indices == [0, 1, 2]
+    b_mse_seq = [fr["b_mse"] for fr in manifest["frontier"]]
+    assert b_mse_seq == [6, 5, 4]
+
+
+def test_idempotent_re_aggregation(tmp_path: Path) -> None:
+    """Re-running aggregator on same dir overwrites manifest cleanly."""
+    for idx, b in enumerate([6, 5]):
+        _write_point(tmp_path, _make_point_json(point_index=idx, b_mse=b))
+
+    _aggregate(tmp_path, [6, 5])
+    manifest_path = tmp_path / "sweep_manifest.json"
+    assert manifest_path.exists()
+    first = json.loads(manifest_path.read_text())
+
+    # Add a point and re-aggregate
+    _write_point(tmp_path, _make_point_json(point_index=2, b_mse=4))
+    second = _aggregate(tmp_path, [6, 5, 4])
+    assert len(first["points"]) == 2
+    assert len(second["points"]) == 3
+
+
+def test_manifest_schema_fields_present(tmp_path: Path) -> None:
+    """Aggregate manifest carries all §6.2 required top-level fields."""
+    _write_point(tmp_path, _make_point_json(point_index=0, b_mse=4))
+    manifest = _aggregate(tmp_path, [4])
+
+    required = {
+        "schema_version", "diagnostic_run_id", "timestamp_utc",
+        "tern_core_version", "tern_core_git_commit", "spec_version",
+        "methodology_consumed", "inputs", "points", "frontier",
+        "recommended_operating_point", "termination", "hardware", "notes",
+    }
+    assert required.issubset(manifest.keys())
+    assert manifest["spec_version"].startswith("kv_cache_compression_ppl_headroom_diagnostic")
+
+
+@pytest.mark.parametrize("b_mse,expected_ratio", [(1, 16.0), (2, 8.0), (4, 4.0), (8, 2.0)])
+def test_compression_ratio_in_frontier(tmp_path: Path, b_mse: int, expected_ratio: float) -> None:
+    """Frontier entry carries kv_cache_compression_ratio from per-point JSON."""
+    _write_point(tmp_path, _make_point_json(point_index=0, b_mse=b_mse))
+    manifest = _aggregate(tmp_path, [b_mse])
+    assert manifest["frontier"][0]["kv_cache_compression_ratio"] == expected_ratio

--- a/tools/tern_r12_sweep.py
+++ b/tools/tern_r12_sweep.py
@@ -437,9 +437,27 @@ def _tern_core_version() -> str:
 
 
 def run_sweep(args: argparse.Namespace) -> SweepResult:
-    """Main sweep orchestration: load model once, loop over b_mse points."""
-    diagnostic_run_id = str(uuid.uuid4())
-    sweep_dir_name = f"sweep_{tern_ppl_bench.utc_now_compact()}_{diagnostic_run_id[:8]}"
+    """Main sweep orchestration: load model once, loop over b_mse points.
+
+    Optional argparse overrides (per-point process-split orchestrator support,
+    additive 2026-05-18):
+      args.diagnostic_run_id    — reuse a caller-minted run_id (default: mint)
+      args.output_subdir        — reuse a caller-minted sweep subdir name
+                                  (default: sweep_<UTC>_<runid8>)
+      args.point_index_offset   — absolute point-index for the first b_mse in
+                                  this invocation's grid (default: 0). Per-point
+                                  invocations pass the absolute sweep index so
+                                  per-point JSON filenames carry the correct
+                                  absolute index across separated subprocesses.
+    """
+    diagnostic_run_id = (
+        getattr(args, "diagnostic_run_id", None) or str(uuid.uuid4())
+    )
+    sweep_dir_name = (
+        getattr(args, "output_subdir", None)
+        or f"sweep_{tern_ppl_bench.utc_now_compact()}_{diagnostic_run_id[:8]}"
+    )
+    point_index_offset = getattr(args, "point_index_offset", 0) or 0
     output_dir = Path(args.output_dir) / sweep_dir_name
     output_dir.mkdir(parents=True, exist_ok=True)
 
@@ -498,7 +516,8 @@ def run_sweep(args: argparse.Namespace) -> SweepResult:
     failed_at_b_mse: Optional[int] = None
     total_eval_wall = 0.0
 
-    for idx, b_mse in enumerate(b_mse_values):
+    for local_idx, b_mse in enumerate(b_mse_values):
+        idx = local_idx + point_index_offset
         print(f"\n[r12_sweep] === point {idx} (b_mse={b_mse}) ===", flush=True)
         point_t0 = time.perf_counter()
         point_result = run_sweep_point(
@@ -622,6 +641,21 @@ def main() -> None:
     parser.add_argument("--notes", default="")
     parser.add_argument("--smoke", action="store_true",
                         help="Reduced-param smoke mode: b_mse=[4,2], N=2, L=128")
+    # Per-point process-split orchestrator support (additive 2026-05-18)
+    parser.add_argument("--diagnostic-run-id", default=None,
+                        help="Reuse a caller-minted diagnostic_run_id (uuid4); "
+                             "default = mint per invocation")
+    parser.add_argument("--output-subdir", default=None,
+                        help="Reuse a caller-minted sweep subdir name under "
+                             "--output-dir; default = sweep_<UTC>_<runid8>")
+    parser.add_argument("--skip-manifest", action="store_true",
+                        help="Skip writing sweep_manifest.json (per-point "
+                             "invocation; orchestrator aggregates post-loop)")
+    parser.add_argument("--point-index-offset", type=int, default=0,
+                        help="Absolute point-index for the first b_mse in this "
+                             "invocation's grid (default 0). Used by the "
+                             "per-point orchestrator so filenames carry the "
+                             "correct absolute index across subprocesses.")
 
     args = parser.parse_args()
 
@@ -638,6 +672,18 @@ def main() -> None:
         )
 
     sweep_result = run_sweep(args)
+
+    if args.skip_manifest:
+        print(
+            f"\n[r12_sweep] === POINT(S) COMPLETE (manifest skipped per "
+            f"--skip-manifest) ===\n"
+            f"[r12_sweep] termination: {sweep_result.termination_reason}\n"
+            f"[r12_sweep] points completed: "
+            f"{len(sweep_result.point_results)}\n"
+            f"[r12_sweep] output_dir: {sweep_result.output_dir}",
+            flush=True,
+        )
+        return
 
     # Build + write aggregate manifest
     b_mse_list = [int(x.strip()) for x in args.b_mse_values.split(",") if x.strip()]

--- a/tools/tern_r12_sweep_aggregate.py
+++ b/tools/tern_r12_sweep_aggregate.py
@@ -1,0 +1,267 @@
+"""R12 v1.2 aggregator: build sweep_manifest.json from per-point JSONs.
+
+Standalone aggregator for the per-point process-split orchestrator
+(tern_r12_sweep_orchestrator.py). Scans a sweep directory for per-point
+JSONs conforming to ppl_headroom_kv_cache_point/1.0, reconstructs
+SweepPointResult shells, and reuses tern_r12_sweep.build_sweep_manifest()
+to emit an aggregate manifest conforming to ppl_headroom_kv_cache_sweep/1.0
+(R12 v1.2 §6.2).
+
+Two invocation modes:
+
+1. Library mode (orchestrator path) — aggregate_sweep_directory() takes the
+   sweep_dir, the inputs dict (baseline_ppl, baseline_run_id, ...), and an
+   externally-measured total_eval_wall_time_seconds; returns the manifest
+   path. The orchestrator measures wall-time across per-point subprocesses
+   and passes the total here.
+
+2. CLI mode (post-hoc recovery) — `python tern_r12_sweep_aggregate.py
+   <sweep_dir> [--baseline-ppl ...] [...]` reads per-point JSONs from a
+   crashed-or-completed sweep directory and emits a manifest. Total
+   wall-time defaults to the sum of point JSONs' eval_wall_time_seconds
+   if present; otherwise 0.0 with a notes-field flag.
+
+The aggregator is pure over per-point JSONs — re-running it on a partial
+sweep produces a valid manifest with termination_reason inferred from the
+point set (incomplete | ceiling_crossed | hook_construction_failure |
+ppl_eval_failure | grid_exhausted).
+
+Copyright (c) 2025-2026 Gamma Seeds Pte Ltd. All rights reserved.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Optional
+
+# Ensure tern_r12_sweep is importable as a sibling module under tools/
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import tern_r12_sweep  # noqa: E402
+from tern_r12_sweep import (  # noqa: E402
+    SweepPointResult,
+    SweepResult,
+    build_sweep_manifest,
+)
+
+
+POINT_FILENAME_RE = re.compile(r"^point_(\d+)_b_mse_(\d+)_.*\.json$")
+
+
+def _point_result_from_json(payload: dict, filename: str) -> SweepPointResult:
+    """Reconstruct a SweepPointResult shell from a per-point JSON payload.
+
+    Per-point JSON does NOT carry factory_build_seconds / eval_wall_time_seconds
+    / tokens_scored / error_traceback (per §6.1 schema). Shell sets those to
+    zero/None — they are not used by build_sweep_manifest() except for the
+    aggregate total_eval_wall_time, which the orchestrator measures externally
+    and passes through SweepResult.total_eval_wall_time_seconds.
+    """
+    return SweepPointResult(
+        point_index=payload["point_index"],
+        b_mse=payload["config"]["b_mse"],
+        ppl_eval_run_id=payload["ppl_eval_run_id"],
+        ppl_kv_compressed=payload.get("ppl_kv_compressed"),
+        ppl_headroom=payload.get("ppl_headroom"),
+        ppl_headroom_band=payload.get("ppl_headroom_band"),
+        kv_cache_compression_ratio=payload.get("kv_cache_compression_ratio"),
+        factory_build_seconds=0.0,
+        eval_wall_time_seconds=0.0,
+        tokens_scored=0,
+        terminated_at_ceiling=bool(payload.get("terminated_at_ceiling", False)),
+        hook_construction_failed=bool(payload.get("hook_construction_failed", False)),
+        error_traceback=None,
+        notes=payload.get("notes", ""),
+        output_filename=filename,
+    )
+
+
+def _scan_point_jsons(sweep_dir: Path) -> list[tuple[int, int, Path, dict]]:
+    """Return [(point_index, b_mse, path, payload), ...] sorted by point_index."""
+    rows: list[tuple[int, int, Path, dict]] = []
+    for path in sorted(sweep_dir.glob("point_*.json")):
+        m = POINT_FILENAME_RE.match(path.name)
+        if not m:
+            continue
+        payload = json.loads(path.read_text())
+        rows.append((payload["point_index"], payload["config"]["b_mse"], path, payload))
+    rows.sort(key=lambda r: r[0])
+    return rows
+
+
+def _infer_termination(
+    point_results: list[SweepPointResult],
+    expected_b_mse_grid: Optional[list[int]],
+    continue_past_ceiling: bool,
+) -> tuple[str, Optional[int], Optional[int]]:
+    """Infer termination_reason / terminated_at_point_index / failed_at_b_mse.
+
+    Mirrors tern_r12_sweep.detect_termination() semantics, applied across the
+    point set on disk rather than as a live sweep decision.
+    """
+    for p in point_results:
+        if p.hook_construction_failed:
+            return ("hook_construction_failure", p.point_index, p.b_mse)
+        if p.terminated_at_ceiling and not continue_past_ceiling:
+            return ("ceiling_crossed", p.point_index, p.b_mse)
+    # ppl_eval_failure: ppl_kv_compressed is None without hook_construction_failed
+    first_failure: Optional[SweepPointResult] = None
+    for p in point_results:
+        if p.ppl_kv_compressed is None and not p.hook_construction_failed:
+            first_failure = p
+            break
+    if expected_b_mse_grid is not None:
+        completed = {p.b_mse for p in point_results}
+        missing = [b for b in expected_b_mse_grid if b not in completed]
+        if missing:
+            # Sweep was halted mid-run by something other than a recorded
+            # ceiling_crossed / hook_construction_failure point. Most common
+            # cause: subprocess killed by OS (libdispatch, OOM, SIGKILL).
+            last = point_results[-1] if point_results else None
+            return (
+                "incomplete",
+                last.point_index if last else None,
+                last.b_mse if last else None,
+            )
+    if first_failure is not None:
+        return ("ppl_eval_failure", first_failure.point_index, first_failure.b_mse)
+    return ("grid_exhausted", None, None)
+
+
+def aggregate_sweep_directory(
+    *,
+    sweep_dir: Path,
+    diagnostic_run_id: str,
+    inputs: dict,
+    calibration_gate_pct: float,
+    device: str,
+    notes: str,
+    total_eval_wall_time_seconds: float,
+    expected_b_mse_grid: Optional[list[int]] = None,
+    continue_past_ceiling: bool = False,
+) -> Path:
+    """Aggregate per-point JSONs under sweep_dir into sweep_manifest.json.
+
+    Returns the manifest path. Idempotent: re-running overwrites the manifest.
+    """
+    rows = _scan_point_jsons(sweep_dir)
+    point_results = [_point_result_from_json(payload, path.name) for (_, _, path, payload) in rows]
+
+    termination_reason, terminated_at_point_index, failed_at_b_mse = _infer_termination(
+        point_results, expected_b_mse_grid, continue_past_ceiling,
+    )
+
+    sweep_result = SweepResult(
+        diagnostic_run_id=diagnostic_run_id,
+        point_results=point_results,
+        termination_reason=termination_reason,
+        terminated_at_point_index=terminated_at_point_index,
+        failed_at_b_mse=failed_at_b_mse,
+        total_eval_wall_time_seconds=total_eval_wall_time_seconds,
+        output_dir=sweep_dir,
+        manifest_path=None,
+    )
+
+    manifest = build_sweep_manifest(
+        sweep_result=sweep_result,
+        inputs=inputs,
+        calibration_gate_pct=calibration_gate_pct,
+        device=device,
+        notes=notes,
+    )
+
+    manifest_path = sweep_dir / "sweep_manifest.json"
+    manifest_path.write_text(json.dumps(manifest, indent=2) + "\n")
+    return manifest_path
+
+
+def _cli_aggregate(args: argparse.Namespace) -> None:
+    sweep_dir = Path(args.sweep_dir).resolve()
+    if not sweep_dir.is_dir():
+        raise SystemExit(f"sweep_dir not a directory: {sweep_dir}")
+
+    rows = _scan_point_jsons(sweep_dir)
+    if not rows:
+        raise SystemExit(f"no point_*.json files found under {sweep_dir}")
+
+    # Reuse the first point's diagnostic_run_id if --diagnostic-run-id omitted
+    diagnostic_run_id = args.diagnostic_run_id or rows[0][3]["diagnostic_run_id"]
+
+    # Reconstruct grid + inputs from first point's payload when CLI args omitted
+    first = rows[0][3]
+    b_mse_grid = (
+        [int(x.strip()) for x in args.b_mse_grid.split(",") if x.strip()]
+        if args.b_mse_grid else [b for (_, b, _, _) in rows]
+    )
+
+    inputs = {
+        "source_model": args.model_id or first["config"]["model_id"],
+        "baseline_ppl_r7b": args.baseline_ppl if args.baseline_ppl is not None
+                            else first["baseline_ppl_r7b"],
+        "baseline_run_id": args.baseline_run_id or "<unknown; post-hoc aggregate>",
+        "ppl_headroom_ceiling": args.ceiling_multiplier - 1.0,
+        "sweep_grid": {"b_mse": b_mse_grid},
+        "num_sequences": args.num_sequences if args.num_sequences is not None
+                         else first["config"]["num_sequences"],
+        "seq_len": args.seq_len if args.seq_len is not None
+                   else first["config"]["seq_len"],
+        "seed": args.seed,
+        "continue_past_ceiling": args.continue_past_ceiling,
+    }
+
+    notes = args.notes or (
+        "post-hoc aggregation via tern_r12_sweep_aggregate.py CLI; "
+        "total_eval_wall_time_seconds=0.0 because per-point JSONs do not "
+        "carry eval_wall_time_seconds (R12 v1.2 §6.1)"
+    )
+
+    manifest_path = aggregate_sweep_directory(
+        sweep_dir=sweep_dir,
+        diagnostic_run_id=diagnostic_run_id,
+        inputs=inputs,
+        calibration_gate_pct=args.calibration_gate_pct,
+        device=args.device,
+        notes=notes,
+        total_eval_wall_time_seconds=args.total_eval_wall_time_seconds,
+        expected_b_mse_grid=b_mse_grid,
+        continue_past_ceiling=args.continue_past_ceiling,
+    )
+    print(f"[r12_aggregate] manifest written: {manifest_path}", flush=True)
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(
+        description="Aggregate per-point JSONs under a sweep directory into "
+                    "sweep_manifest.json (R12 v1.2 §6.2). Post-hoc-safe."
+    )
+    p.add_argument("sweep_dir", help="Directory containing point_*.json files")
+    p.add_argument("--diagnostic-run-id", default=None,
+                   help="Override diagnostic_run_id (default: reuse first point's)")
+    p.add_argument("--model-id", default=None)
+    p.add_argument("--baseline-ppl", type=float, default=None)
+    p.add_argument("--baseline-run-id", default=None)
+    p.add_argument("--b-mse-grid", default=None,
+                   help="Expected b_mse grid for termination inference, e.g. '6,5,4,3,2,1'")
+    p.add_argument("--num-sequences", type=int, default=None)
+    p.add_argument("--seq-len", type=int, default=None)
+    p.add_argument("--device", default="mps", choices=["mps", "cpu"])
+    p.add_argument("--calibration-gate-pct", type=float,
+                   default=tern_r12_sweep.DEFAULT_CALIBRATION_GATE_PCT)
+    p.add_argument("--ceiling-multiplier", type=float,
+                   default=tern_r12_sweep.DEFAULT_CEILING_MULTIPLIER)
+    p.add_argument("--continue-past-ceiling", action="store_true",
+                   default=tern_r12_sweep.DEFAULT_CONTINUE_PAST_CEILING)
+    p.add_argument("--seed", type=int, default=tern_r12_sweep.DEFAULT_SEED)
+    p.add_argument("--total-eval-wall-time-seconds", type=float, default=0.0,
+                   help="Total wall-time across points (orchestrator-measured); "
+                        "default 0.0 for post-hoc aggregation")
+    p.add_argument("--notes", default="")
+    args = p.parse_args()
+    _cli_aggregate(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/tern_r12_sweep_orchestrator.py
+++ b/tools/tern_r12_sweep_orchestrator.py
@@ -1,0 +1,338 @@
+"""R12 v1.2 per-point process-split orchestrator (libdispatch-trap mitigation).
+
+Runs each b_mse sweep point in a fresh Python subprocess so that MPS allocator
+state (and any other per-process global) cannot accumulate across points.
+Motivated by lesson 16 (feedback_process_death_evidence_completeness_v1) and
+the 2026-05-18 A'' R12 sweep PID 8767 failure: PyTorch MPS libdispatch
+reentrant deadlock terminated a single long-running process mid-point-0,
+leaving no per-point JSON written.
+
+Architecture:
+  - Mint diagnostic_run_id + sweep subdir name ONCE here.
+  - For each b_mse: spawn `python tools/tern_r12_sweep.py
+      --b-mse-values <one> --diagnostic-run-id <id> --output-subdir <subdir>
+      --skip-manifest ...` via subprocess.Popen so PID is captured.
+  - Wait for the subprocess; measure wall-time around it.
+  - Read the just-written per-point JSON; apply detect_termination() to
+    decide whether to launch the next point (halt on ceiling_crossed /
+    hook_construction_failure; continue past ppl_eval_failure).
+  - After loop: call aggregate_sweep_directory() with the orchestrator-
+    measured total_eval_wall_time_seconds.
+
+The model loads fresh per subprocess (~30-60s on Mac for Gemma 4 E4B). Across
+6 canonical points that's ~3-6 min added wall-clock vs the single-process
+sweep — accepted cost of MPS-allocator-state isolation.
+
+Smoke mode (--smoke): b_mse=[4,2], N=2, L=128. Passes those values
+EXPLICITLY to each subprocess via --b-mse-values "<one>" (NOT via --smoke,
+which would hardcode b_mse=[4,2] inside each subprocess and silently
+re-expand the per-point invocation back to multi-point).
+
+Copyright (c) 2025-2026 Gamma Seeds Pte Ltd. All rights reserved.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import time
+import uuid
+from pathlib import Path
+from typing import Optional
+
+# Ensure sibling modules are importable
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import tern_r12_sweep  # noqa: E402
+import tern_ppl_bench  # noqa: E402
+from tern_r12_sweep_aggregate import aggregate_sweep_directory  # noqa: E402
+
+
+SWEEP_SCRIPT = Path(__file__).resolve().parent / "tern_r12_sweep.py"
+POINT_FILENAME_RE = re.compile(r"^point_(\d+)_b_mse_(\d+)_.*\.json$")
+
+# Smoke defaults — explicit per-point fanout (DO NOT pass --smoke to children)
+SMOKE_B_MSE_GRID = [4, 2]
+SMOKE_NUM_SEQUENCES = 2
+SMOKE_AR_SEQ_LEN = 128
+
+
+def _build_point_argv(
+    *,
+    python: str,
+    b_mse: int,
+    point_index: int,
+    args: argparse.Namespace,
+    diagnostic_run_id: str,
+    output_subdir: str,
+) -> list[str]:
+    """Build the argv for one per-point subprocess invocation."""
+    return [
+        python, str(SWEEP_SCRIPT),
+        "--model-id", args.model_id,
+        "--baseline-run-id", args.baseline_run_id,
+        "--baseline-ppl", str(args.baseline_ppl),
+        "--b-mse-values", str(b_mse),
+        "--num-sequences", str(args.num_sequences),
+        "--ar-seq-len", str(args.ar_seq_len),
+        "--device", args.device,
+        "--hook-spec", args.hook_spec,
+        "--output-dir", args.output_dir,
+        "--calibration-gate-pct", str(args.calibration_gate_pct),
+        "--ceiling-multiplier", str(args.ceiling_multiplier),
+        "--seed", str(args.seed),
+        "--diagnostic-run-id", diagnostic_run_id,
+        "--output-subdir", output_subdir,
+        "--point-index-offset", str(point_index),
+        "--skip-manifest",
+    ]
+
+
+def _read_point_json(sweep_dir: Path, point_index: int, b_mse: int) -> Optional[dict]:
+    """Read the per-point JSON written by the just-finished subprocess.
+
+    Subprocess writes filename `point_<NN>_b_mse_<B>_<runid>.json`. The runid
+    suffix is unknown to the orchestrator, so we glob by (point_index, b_mse).
+    Returns None if no matching file (subprocess died before write).
+    """
+    pattern = f"point_{point_index:02d}_b_mse_{b_mse}_*.json"
+    matches = list(sweep_dir.glob(pattern))
+    if not matches:
+        return None
+    if len(matches) > 1:
+        # Multiple writes for same (idx, b_mse) — last-wins by mtime
+        matches.sort(key=lambda p: p.stat().st_mtime)
+    return json.loads(matches[-1].read_text())
+
+
+def _termination_from_point_json(
+    payload: dict, continue_past_ceiling: bool,
+) -> Optional[str]:
+    """Decide halt-or-continue from a per-point JSON payload.
+
+    Mirrors tern_r12_sweep.detect_termination() but reads from JSON dict
+    rather than SweepPointResult dataclass.
+    """
+    if payload.get("hook_construction_failed", False):
+        return "hook_construction_failure"
+    if payload.get("ppl_kv_compressed") is None:
+        return "ppl_eval_failure"
+    if payload.get("terminated_at_ceiling", False) and not continue_past_ceiling:
+        return "ceiling_crossed"
+    return None
+
+
+def run_orchestrated_sweep(args: argparse.Namespace) -> Path:
+    """Orchestrate per-point sweep; return manifest path."""
+    diagnostic_run_id = str(uuid.uuid4())
+    sweep_dir_name = (
+        f"sweep_{tern_ppl_bench.utc_now_compact()}_{diagnostic_run_id[:8]}"
+    )
+    sweep_dir = Path(args.output_dir) / sweep_dir_name
+    sweep_dir.mkdir(parents=True, exist_ok=True)
+
+    b_mse_grid = [int(x.strip()) for x in args.b_mse_values.split(",") if x.strip()]
+    python = args.python or sys.executable
+
+    print(
+        f"[r12_orchestrator] diagnostic_run_id={diagnostic_run_id}\n"
+        f"[r12_orchestrator] sweep_dir={sweep_dir}\n"
+        f"[r12_orchestrator] python={python}\n"
+        f"[r12_orchestrator] grid: b_mse={b_mse_grid}, N={args.num_sequences}, "
+        f"L={args.ar_seq_len}, device={args.device}, hook={args.hook_spec}\n"
+        f"[r12_orchestrator] per-point process split active "
+        f"(lesson 16 / libdispatch mitigation)",
+        flush=True,
+    )
+
+    total_wall = 0.0
+    points_launched = 0
+    halted_reason: Optional[str] = None
+
+    for idx, b_mse in enumerate(b_mse_grid):
+        argv = _build_point_argv(
+            python=python, b_mse=b_mse, point_index=idx, args=args,
+            diagnostic_run_id=diagnostic_run_id, output_subdir=sweep_dir_name,
+        )
+        print(
+            f"\n[r12_orchestrator] === launching point {idx} (b_mse={b_mse}) ===",
+            flush=True,
+        )
+        t0 = time.perf_counter()
+        proc = subprocess.Popen(argv)
+        pid = proc.pid
+        print(
+            f"[r12_orchestrator]   PID={pid} (fresh process; "
+            f"MPS allocator state isolated)",
+            flush=True,
+        )
+        returncode = proc.wait()
+        wall = time.perf_counter() - t0
+        total_wall += wall
+        points_launched += 1
+
+        print(
+            f"[r12_orchestrator]   PID={pid} exited rc={returncode} "
+            f"wall={wall:.1f}s ({wall / 60:.2f} min)",
+            flush=True,
+        )
+
+        payload = _read_point_json(sweep_dir, idx, b_mse)
+        if payload is None:
+            # Subprocess died before writing per-point JSON. Halt — sweep is
+            # incomplete; surface for surgeon disposition.
+            print(
+                f"[r12_orchestrator] HALT: no per-point JSON written for "
+                f"point {idx} (b_mse={b_mse}); subprocess (PID={pid}) likely "
+                f"died before write. Inspect ~/Library/Logs/DiagnosticReports/ "
+                f"per lesson 16. Aggregator will mark termination as "
+                f"'incomplete'.",
+                flush=True,
+            )
+            halted_reason = "subprocess_died_pre_write"
+            break
+
+        # Surface point summary
+        print(
+            f"[r12_orchestrator]   ppl_kv={payload.get('ppl_kv_compressed')}, "
+            f"headroom={payload.get('ppl_headroom')}, "
+            f"band={payload.get('ppl_headroom_band')}, "
+            f"ceiling_crossed={payload.get('terminated_at_ceiling')}, "
+            f"hook_failed={payload.get('hook_construction_failed')}",
+            flush=True,
+        )
+
+        reason = _termination_from_point_json(payload, args.continue_past_ceiling)
+        if reason == "hook_construction_failure":
+            print(
+                f"[r12_orchestrator] HALT: hook_construction_failure at "
+                f"b_mse={b_mse}",
+                flush=True,
+            )
+            halted_reason = reason
+            break
+        if reason == "ceiling_crossed":
+            print(
+                f"[r12_orchestrator] HALT: ceiling_crossed at b_mse={b_mse} "
+                f"(continue_past_ceiling={args.continue_past_ceiling})",
+                flush=True,
+            )
+            halted_reason = reason
+            break
+        if reason == "ppl_eval_failure":
+            print(
+                f"[r12_orchestrator] continuing past ppl_eval_failure at "
+                f"b_mse={b_mse} (less-aggressive b_mse may still succeed)",
+                flush=True,
+            )
+
+    # Build inputs dict for aggregator (matches build_sweep_manifest contract)
+    inputs = {
+        "source_model": args.model_id,
+        "baseline_ppl_r7b": args.baseline_ppl,
+        "baseline_run_id": args.baseline_run_id,
+        "ppl_headroom_ceiling": args.ceiling_multiplier - 1.0,
+        "sweep_grid": {"b_mse": b_mse_grid},
+        "num_sequences": args.num_sequences,
+        "seq_len": args.ar_seq_len,
+        "seed": args.seed,
+        "continue_past_ceiling": args.continue_past_ceiling,
+    }
+
+    notes_parts = [args.notes] if args.notes else []
+    notes_parts.append(
+        "per-point process-split orchestration "
+        "(tern_r12_sweep_orchestrator.py, lesson 16 mitigation; "
+        "MPS allocator state isolated across points)"
+    )
+    if halted_reason == "subprocess_died_pre_write":
+        notes_parts.append(
+            "sweep halted: subprocess died before writing per-point JSON; "
+            "termination_reason inferred as 'incomplete'"
+        )
+
+    manifest_path = aggregate_sweep_directory(
+        sweep_dir=sweep_dir,
+        diagnostic_run_id=diagnostic_run_id,
+        inputs=inputs,
+        calibration_gate_pct=args.calibration_gate_pct,
+        device=args.device,
+        notes="; ".join(notes_parts),
+        total_eval_wall_time_seconds=total_wall,
+        expected_b_mse_grid=b_mse_grid,
+        continue_past_ceiling=args.continue_past_ceiling,
+    )
+
+    # Read back the manifest for the closing summary
+    manifest = json.loads(manifest_path.read_text())
+    rec = manifest["recommended_operating_point"]
+    print(
+        f"\n[r12_orchestrator] === ORCHESTRATED SWEEP COMPLETE ===\n"
+        f"[r12_orchestrator] termination: {manifest['termination']['terminated_reason']}\n"
+        f"[r12_orchestrator] points launched: {points_launched} / {len(b_mse_grid)}\n"
+        f"[r12_orchestrator] total wall (sum of subprocesses): "
+        f"{total_wall:.1f}s ({total_wall / 60:.1f} min)\n"
+        f"[r12_orchestrator] recommended_operating_point: "
+        f"b_mse={rec.get('b_mse')}, headroom={rec.get('ppl_headroom')}\n"
+        f"[r12_orchestrator] manifest: {manifest_path}",
+        flush=True,
+    )
+    return manifest_path
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(
+        description="R12 v1.2 per-point process-split orchestrator. "
+                    "Runs each b_mse point in a fresh Python subprocess to "
+                    "isolate MPS allocator state (lesson 16 / libdispatch "
+                    "mitigation)."
+    )
+    # Mirror tern_r12_sweep.py's required + defaultable args
+    p.add_argument("--model-id", required=True)
+    p.add_argument("--baseline-run-id", required=True)
+    p.add_argument("--baseline-ppl", required=True, type=float)
+    p.add_argument("--b-mse-values", default=tern_r12_sweep.DEFAULT_B_MSE_VALUES)
+    p.add_argument("--num-sequences", default=tern_r12_sweep.DEFAULT_NUM_SEQUENCES,
+                   type=int)
+    p.add_argument("--ar-seq-len", default=tern_r12_sweep.DEFAULT_AR_SEQ_LEN,
+                   type=int)
+    p.add_argument("--device", default=tern_r12_sweep.DEFAULT_DEVICE,
+                   choices=["mps", "cpu"])
+    p.add_argument("--hook-spec", default=tern_r12_sweep.DEFAULT_HOOK_SPEC,
+                   choices=["uniform", "mixed"])
+    p.add_argument("--output-dir", default=tern_r12_sweep.DEFAULT_OUTPUT_DIR)
+    p.add_argument("--calibration-gate-pct",
+                   default=tern_r12_sweep.DEFAULT_CALIBRATION_GATE_PCT, type=float)
+    p.add_argument("--ceiling-multiplier",
+                   default=tern_r12_sweep.DEFAULT_CEILING_MULTIPLIER, type=float)
+    p.add_argument("--continue-past-ceiling", action="store_true",
+                   default=tern_r12_sweep.DEFAULT_CONTINUE_PAST_CEILING)
+    p.add_argument("--seed", default=tern_r12_sweep.DEFAULT_SEED, type=int)
+    p.add_argument("--notes", default="")
+    p.add_argument("--smoke", action="store_true",
+                   help="Reduced-param smoke mode: b_mse=[4,2], N=2, L=128")
+    p.add_argument("--python", default=None,
+                   help="Python interpreter for subprocesses (default: sys.executable)")
+
+    args = p.parse_args()
+
+    if args.smoke:
+        args.b_mse_values = ",".join(str(b) for b in SMOKE_B_MSE_GRID)
+        args.num_sequences = SMOKE_NUM_SEQUENCES
+        args.ar_seq_len = SMOKE_AR_SEQ_LEN
+        if not args.notes:
+            args.notes = ("R12 v1.2 per-point process-split orchestrator "
+                          "smoke mode")
+        print(
+            f"[r12_orchestrator] SMOKE MODE: b_mse={args.b_mse_values}, "
+            f"N={args.num_sequences}, L={args.ar_seq_len}",
+            flush=True,
+        )
+
+    run_orchestrated_sweep(args)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Per-point process-split orchestrator for the R12 v1.2 b_mse sweep — each point runs in a fresh Python subprocess so PyTorch MPS allocator state cannot accumulate across points.

**Motivation:** Lesson 16 (`feedback_process_death_evidence_completeness_v1.md`) + the 2026-05-18 A'' R12 sweep PID 8767 failure. A single long-running Python process accumulated MPS allocator state until libdispatch reentrant deadlock terminated it mid-point-0, leaving no per-point JSON written. Application log under-attributed the cause (looked like external termination); `~/Library/Logs/DiagnosticReports/` Problem Report disambiguated to internal abort.

**Trade-off:** Each subprocess re-loads the model (~3-5s for TinyLlama-1.1B on MPS; ~30-60s for Gemma 4 E4B). Across the canonical 6-point grid that's seconds to minutes of added wall-clock vs single-process. Accepted cost of MPS-allocator-state isolation.

## Components

| File | Change | LOC |
|---|---|---|
| `tools/tern_r12_sweep_orchestrator.py` | new — fans out per-point subprocesses via `subprocess.Popen` (PID captured + logged); reads each per-point JSON to drive halt-or-continue; invokes aggregator post-loop with orchestrator-measured total wall. | +338 |
| `tools/tern_r12_sweep_aggregate.py` | new — pure-function aggregator over a sweep dir; reuses `tern_r12_sweep.build_sweep_manifest` + `classify_recommended_operating_point`; infers `termination_reason` (`incomplete` / `ceiling_crossed` / `hook_construction_failure` / `ppl_eval_failure` / `grid_exhausted`) from the point set on disk. Library + CLI modes; CLI mode supports post-hoc recovery from a crashed sweep. | +267 |
| `tools/tern_r12_sweep.py` | additive CLI: `--diagnostic-run-id`, `--output-subdir`, `--skip-manifest`, `--point-index-offset`. Single-process multi-point behaviour unchanged when no new flags are set. | +50 / -4 |
| `tests/test_r12_sweep_aggregate.py` | new — 14 unit tests covering happy path, ceiling_crossed (halt + continue-past), hook_construction_failure, ppl_eval_failure, incomplete-from-subprocess-death, recommended-op null-stub, point-ordering, idempotent re-aggregation, manifest schema fields, parameterised compression ratios. | +302 |

Total: **+957 / -4** across 4 files.

## Design notes

**Aggregation strategy:** Per-point Python writes its own JSON only (existing R12 v1.2 §6.1 contract); orchestrator measures subprocess wall-time externally; separate aggregator script invoked post-loop. Standalone aggregator means a crashed sweep can be recovered post-hoc by running `python tools/tern_r12_sweep_aggregate.py <sweep_dir>`.

**Backwards compatibility:** All `tern_r12_sweep.py` changes are additive CLI args. The existing multi-point single-process invocation continues to work unchanged. The orchestrator passes explicit reduced params (NOT `--smoke`) to each subprocess so the smoke flag's `b_mse=[4,2]` hardcode does not silently re-expand a per-point invocation back to multi-point.

**Index propagation:** `--point-index-offset` lets each subprocess know its absolute sweep index. Without this, every per-point subprocess would emit `point_index=0` (it enumerates its own 1-element grid from 0). This was caught + fixed during Phase E.2 smoke; surfaced here for future readers.

## Test plan

- [x] **Aggregator unit tests** — `pytest tests/test_r12_sweep_aggregate.py -v` → 14 / 14 PASS in 0.7s
- [x] **Phase E.1 single-point smoke** (TinyLlama-1.1B, MPS, b_mse=4, N=2, L=128): PID 3877 produced conformant per-point JSON; aggregator emitted valid §6.2 manifest; `ceiling_crossed` termination correctly inferred (expected at smoke params).
- [x] **Phase E.2 two-point smoke** (b_mse=[4,2], `--continue-past-ceiling`): distinct PIDs 4139 + 4143 (process isolation verified); `point_index` 0 + 1 correct across subprocesses; `ppl_eval_failure` termination correctly inferred from per-point JSON; frontier ordered [4, 2].
- [ ] **Phase G full canonical re-launch** (TinyLlama-1.1B, b_mse=[6,5,4,3,2,1], N=16, L=2048, MPS, β1a, baseline B run_id 20260516T065626Z, PPL=7.9367): launching from this branch as background process per CC re-launch report.

## Canonical re-launch command (Phase G)

```bash
python tools/tern_r12_sweep_orchestrator.py \
  --model-id TinyLlama/TinyLlama-1.1B-Chat-v1.0 \
  --baseline-run-id 20260516T065626Z \
  --baseline-ppl 7.9367 \
  --b-mse-values "6,5,4,3,2,1" \
  --num-sequences 16 --ar-seq-len 2048 \
  --device mps --hook-spec uniform
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)