### PR TITLE
feat(r12): eval-loop progress instrumentation + R4 aggregator-glob discipline

### DIFF
--- a/tests/test_r12_sweep_aggregate.py
+++ b/tests/test_r12_sweep_aggregate.py
@@ -300,3 +300,70 @@ def test_compression_ratio_in_frontier(tmp_path: Path, b_mse: int, expected_rati
     _write_point(tmp_path, _make_point_json(point_index=0, b_mse=b_mse))
     manifest = _aggregate(tmp_path, [b_mse])
     assert manifest["frontier"][0]["kv_cache_compression_ratio"] == expected_ratio
+
+
+# ── R4 aggregator-glob safety: heartbeat sidecars are ignored ──────────────
+
+
+def test_heartbeat_sidecar_ignored_by_aggregator(tmp_path: Path) -> None:
+    """WS-001 R4: heartbeat sidecars (.jsonl) coexist in sweep dir without
+    being picked up by the aggregator's point_*.json glob.
+
+    Failure mode this guards: if a future change loosens the aggregator's
+    glob (e.g. to `point_*.json*` or similar), a heartbeat sidecar would
+    parse as a per-point JSON, corrupting the manifest or raising on
+    json.loads of a JSONL multi-object file.
+    """
+    grid = [6, 5]
+    for idx, b in enumerate(grid):
+        _write_point(tmp_path, _make_point_json(point_index=idx, b_mse=b))
+
+    # Drop heartbeat sidecars with the canonical filename for each point.
+    # JSONL content (multiple JSON objects, one per line) would raise on
+    # json.loads() — if the aggregator accidentally consumes one, the test
+    # surfaces it as an exception during _aggregate().
+    for idx, b in enumerate(grid):
+        sidecar = tmp_path / f"point_{idx:02d}_b_mse_{b}_heartbeat.jsonl"
+        sidecar.write_text(
+            '{"phase": "eval_start", "n_sequences": 4}\n'
+            '{"phase": "seq_start", "seq": 0, "L_eff": 2049}\n'
+            '{"phase": "seq_end", "seq": 0, "alloc_MB_pre_drain": 120.5}\n'
+        )
+
+    manifest = _aggregate(tmp_path, grid)
+
+    # Aggregator must NOT include heartbeat-sidecar entries in the manifest
+    point_filenames = {pt["filename"] for pt in manifest["points"]}
+    for fn in point_filenames:
+        assert fn.endswith(".json"), (
+            f"heartbeat sidecar leaked into manifest.points: {fn}"
+        )
+        assert "heartbeat" not in fn, (
+            f"heartbeat sidecar leaked into manifest.points: {fn}"
+        )
+    assert len(manifest["points"]) == 2
+    assert manifest["termination"]["terminated_reason"] == "grid_exhausted"
+
+
+def test_heartbeat_sidecar_with_json_extension_would_break(tmp_path: Path) -> None:
+    """Negative-case complement to R4: documents WHY .jsonl extension is
+    load-bearing. If someone misnames a heartbeat file `*_heartbeat.json`
+    (note: no L), the regex ``^point_(\\d+)_b_mse_(\\d+)_.*\\.json$`` would
+    match it, and ``json.loads`` on the multi-line JSONL content would raise.
+
+    This test pins .jsonl extension as the canonical convention by
+    surfacing the failure that would occur if .json were used instead.
+    """
+    grid = [6]
+    _write_point(tmp_path, _make_point_json(point_index=0, b_mse=6))
+
+    bad_sidecar = tmp_path / "point_00_b_mse_6_heartbeat.json"
+    bad_sidecar.write_text(
+        '{"phase": "eval_start"}\n{"phase": "seq_start"}\n'
+    )
+
+    with pytest.raises(Exception):
+        # json.loads on the JSONL content raises; aggregator does not
+        # guard against the misnaming because the canonical extension
+        # convention IS the load-bearing safety.
+        _aggregate(tmp_path, grid)

--- a/tools/tern_ppl_bench.py
+++ b/tools/tern_ppl_bench.py
@@ -29,13 +29,14 @@ import datetime as _dt
 import hashlib
 import json
 import math
+import os
 import subprocess
 import sys
 import time
 import uuid
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Optional, TextIO
 
 import torch
 
@@ -276,11 +277,59 @@ class ARPplResult:
     per_sequence_losses: list[float]
 
 
+def _mps_alloc_mb(device: str) -> Optional[float]:
+    """Return PyTorch MPS allocator's current allocated memory in MB.
+
+    Returns None when device != "mps".
+
+    Uses ``torch.mps.current_allocated_memory()`` (PyTorch allocator's view of
+    currently-in-use bytes) rather than ``driver_allocated_memory()``. The
+    latter was observed reporting virtual-address-space commits (>76 GB on
+    64 GB unified-memory M4 Pro) — useful for OOM diagnostics but misleading
+    as an allocator-pressure proxy. R1 instrumentation surfaced this empirically
+    on 2026-05-18; documented in the WS-001 PR description.
+
+    Numerical-neutrality: counter read with no kernel launch, no dispatch_sync,
+    no MPS->CPU sync side-effect. Safe to call inside the inner loop at
+    per-heartbeat cadence without changing eval semantics.
+    """
+    if device != "mps":
+        return None
+    try:
+        return torch.mps.current_allocated_memory() / (1024 * 1024)
+    except Exception:
+        return None
+
+
+def _emit_heartbeat(
+    *,
+    sidecar: Optional[TextIO],
+    payload: dict,
+    stdout_prefix: str = "[r7b_ar_eval]",
+    stdout_message: str = "",
+) -> None:
+    """Write one heartbeat line to JSONL sidecar (with fsync) + stdout.
+
+    fsync on the sidecar fd guarantees durability across SIGTRAP — the
+    application log may lose the last buffered seconds, but every fsync'd
+    heartbeat line survives.
+    """
+    if sidecar is not None:
+        sidecar.write(json.dumps(payload) + "\n")
+        sidecar.flush()
+        os.fsync(sidecar.fileno())
+    if stdout_message:
+        print(f"{stdout_prefix} {stdout_message}", flush=True)
+
+
 def evaluate_ppl_autoregressive(
     model: Any,
     sequences: list[list[int]],
     kv_cache_hook: Optional[Any] = None,
     device: str = "mps",
+    *,
+    heartbeat_sidecar_path: Optional[Path] = None,
+    heartbeat_token_interval: int = 128,
 ) -> ARPplResult:
     """R7-B v1.1 §5 canonical autoregressive PPL.
 
@@ -297,6 +346,18 @@ def evaluate_ppl_autoregressive(
                         forward calls. Closure lifetime is the caller's
                         concern (one factory per measurement per §5.4).
         device:         Device string for tensor placement.
+
+    Optional progress instrumentation (WS-001, 2026-05-18):
+
+        heartbeat_sidecar_path:
+            If provided, JSONL heartbeat lines are written here with fsync,
+            surviving SIGTRAP. Same lines also go to stdout for live view.
+            Each heartbeat carries cumulative ``total_loss`` + ``total_scored``
+            so the last fsync'd line enables ``ppl_partial = exp(total_loss/
+            total_scored)`` reconstruction if the process traps mid-eval.
+        heartbeat_token_interval:
+            Emit a heartbeat every K inner-loop iterations (default 128).
+            Per-sequence boundary lines (seq_start / seq_end) emit regardless.
     """
     import torch.nn.functional as F
 
@@ -309,39 +370,136 @@ def evaluate_ppl_autoregressive(
     total_scored: int = 0
     per_sequence_losses: list[float] = []
 
-    t_start = time.perf_counter()
-    with torch.no_grad():
-        for seq in sequences:
-            past_kv = None
-            seq_loss: float = 0.0
-            L_eff = len(seq)
-            for t in range(L_eff - 1):
-                input_ids = torch.tensor([[seq[t]]], device=device)
-                outputs = model(
-                    input_ids=input_ids,
-                    past_key_values=past_kv,
-                    use_cache=True,
-                )
-                past_kv = outputs.past_key_values
-                # Per R7-B v1.1 §5.2: kv_cache_hook returns DynamicCache
-                # directly. The legacy-tuple wrapping bridge from PR #30 is
-                # removed; the hook factories (PR #26, PR #27) now produce
-                # Cache-shaped objects natively.
-                past_kv = kv_cache_hook(past_kv)
+    sidecar: Optional[TextIO] = None
+    if heartbeat_sidecar_path is not None:
+        heartbeat_sidecar_path.parent.mkdir(parents=True, exist_ok=True)
+        sidecar = open(heartbeat_sidecar_path, "a", buffering=1)
 
-                logits = outputs.logits[0, -1]
-                target = torch.tensor(seq[t + 1], device=device)
-                # reduction='sum' on a single-position pair gives the
-                # per-token CE; .item() casts to Python float (float64).
-                loss = F.cross_entropy(
-                    logits.unsqueeze(0),
-                    target.unsqueeze(0),
-                    reduction="sum",
-                ).item()
-                seq_loss += loss
-                total_loss += loss
-                total_scored += 1
-            per_sequence_losses.append(seq_loss)
+    t_start = time.perf_counter()
+    _emit_heartbeat(
+        sidecar=sidecar,
+        payload={
+            "t_iso": utc_now_iso(), "wall_s": 0.0, "phase": "eval_start",
+            "n_sequences": len(sequences),
+            "alloc_MB": _mps_alloc_mb(device),
+            "heartbeat_token_interval": heartbeat_token_interval,
+        },
+        stdout_message=(
+            f"eval_start n_sequences={len(sequences)} "
+            f"alloc_MB={_mps_alloc_mb(device)} "
+            f"hb_K={heartbeat_token_interval}"
+        ),
+    )
+
+    try:
+        with torch.no_grad():
+            for seq_idx, seq in enumerate(sequences):
+                past_kv = None
+                seq_loss: float = 0.0
+                L_eff = len(seq)
+                seq_t0 = time.perf_counter()
+                _emit_heartbeat(
+                    sidecar=sidecar,
+                    payload={
+                        "t_iso": utc_now_iso(),
+                        "wall_s": round(time.perf_counter() - t_start, 3),
+                        "seq": seq_idx, "phase": "seq_start", "L_eff": L_eff,
+                        "alloc_MB": _mps_alloc_mb(device),
+                    },
+                    stdout_message=(
+                        f"seq={seq_idx}/{len(sequences)} start L_eff={L_eff} "
+                        f"alloc_MB={_mps_alloc_mb(device)}"
+                    ),
+                )
+
+                for t in range(L_eff - 1):
+                    input_ids = torch.tensor([[seq[t]]], device=device)
+                    outputs = model(
+                        input_ids=input_ids,
+                        past_key_values=past_kv,
+                        use_cache=True,
+                    )
+                    past_kv = outputs.past_key_values
+                    # Per R7-B v1.1 §5.2: kv_cache_hook returns DynamicCache
+                    # directly. The legacy-tuple wrapping bridge from PR #30
+                    # is removed; the hook factories (PR #26, PR #27) now
+                    # produce Cache-shaped objects natively.
+                    past_kv = kv_cache_hook(past_kv)
+
+                    logits = outputs.logits[0, -1]
+                    target = torch.tensor(seq[t + 1], device=device)
+                    # reduction='sum' on a single-position pair gives the
+                    # per-token CE; .item() casts to Python float (float64).
+                    loss = F.cross_entropy(
+                        logits.unsqueeze(0),
+                        target.unsqueeze(0),
+                        reduction="sum",
+                    ).item()
+                    seq_loss += loss
+                    total_loss += loss
+                    total_scored += 1
+
+                    if heartbeat_token_interval > 0 and (
+                        t > 0 and t % heartbeat_token_interval == 0
+                    ):
+                        ppl_partial = (
+                            math.exp(total_loss / total_scored)
+                            if total_scored > 0 else None
+                        )
+                        _emit_heartbeat(
+                            sidecar=sidecar,
+                            payload={
+                                "t_iso": utc_now_iso(),
+                                "wall_s": round(
+                                    time.perf_counter() - t_start, 3
+                                ),
+                                "seq": seq_idx, "phase": "hb",
+                                "token": t, "L_eff": L_eff,
+                                "alloc_MB": _mps_alloc_mb(device),
+                                "total_loss": total_loss,
+                                "total_scored": total_scored,
+                                "ppl_partial": ppl_partial,
+                            },
+                            stdout_message=(
+                                f"seq={seq_idx}/{len(sequences)} hb t={t}/"
+                                f"{L_eff} alloc_MB={_mps_alloc_mb(device)} "
+                                f"ppl_partial={ppl_partial}"
+                            ),
+                        )
+
+                per_sequence_losses.append(seq_loss)
+                seq_wall = time.perf_counter() - seq_t0
+                ppl_partial = (
+                    math.exp(total_loss / total_scored)
+                    if total_scored > 0 else None
+                )
+                _emit_heartbeat(
+                    sidecar=sidecar,
+                    payload={
+                        "t_iso": utc_now_iso(),
+                        "wall_s": round(time.perf_counter() - t_start, 3),
+                        "seq": seq_idx, "phase": "seq_end", "L_eff": L_eff,
+                        "seq_wall_s": round(seq_wall, 3),
+                        "seq_loss": seq_loss,
+                        "total_loss": total_loss,
+                        "total_scored": total_scored,
+                        "ppl_partial": ppl_partial,
+                        "alloc_MB": _mps_alloc_mb(device),
+                    },
+                    stdout_message=(
+                        f"seq={seq_idx}/{len(sequences)} done wall={seq_wall:.1f}s "
+                        f"loss={seq_loss:.4f} ppl_partial={ppl_partial} "
+                        f"alloc_MB={_mps_alloc_mb(device)}"
+                    ),
+                )
+    finally:
+        if sidecar is not None:
+            sidecar.flush()
+            try:
+                os.fsync(sidecar.fileno())
+            except Exception:
+                pass
+            sidecar.close()
 
     eval_wall_time = time.perf_counter() - t_start
 

--- a/tools/tern_r12_sweep.py
+++ b/tools/tern_r12_sweep.py
@@ -210,6 +210,8 @@ def run_sweep_point(
     model_id: str,
     num_sequences: int,
     seq_len: int,
+    heartbeat_sidecar_path: Optional[Path] = None,
+    heartbeat_token_interval: int = 128,
 ) -> SweepPointResult:
     """Execute one b_mse point: build factory, run PPL eval, classify result."""
     run_id = tern_ppl_bench.utc_now_compact()
@@ -251,6 +253,8 @@ def run_sweep_point(
     try:
         result = tern_ppl_bench.evaluate_ppl_autoregressive(
             model=model, sequences=sequences, kv_cache_hook=hook, device=device,
+            heartbeat_sidecar_path=heartbeat_sidecar_path,
+            heartbeat_token_interval=heartbeat_token_interval,
         )
     except Exception as exc:
         return SweepPointResult(
@@ -520,6 +524,15 @@ def run_sweep(args: argparse.Namespace) -> SweepResult:
         idx = local_idx + point_index_offset
         print(f"\n[r12_sweep] === point {idx} (b_mse={b_mse}) ===", flush=True)
         point_t0 = time.perf_counter()
+        # Heartbeat sidecar path (WS-001 r12 eval-loop instrumentation):
+        # filename mirrors per-point JSON but uses .jsonl extension so the
+        # aggregator's point_*.json glob does not pick it up. Sidecar is
+        # OFF by default; orchestrator passes --enable-heartbeat to opt in.
+        heartbeat_sidecar_path: Optional[Path] = None
+        if getattr(args, "enable_heartbeat", False):
+            heartbeat_sidecar_path = (
+                output_dir / f"point_{idx:02d}_b_mse_{b_mse}_heartbeat.jsonl"
+            )
         point_result = run_sweep_point(
             point_index=idx,
             b_mse=b_mse,
@@ -532,6 +545,8 @@ def run_sweep(args: argparse.Namespace) -> SweepResult:
             model_id=args.model_id,
             num_sequences=args.num_sequences,
             seq_len=args.ar_seq_len,
+            heartbeat_sidecar_path=heartbeat_sidecar_path,
+            heartbeat_token_interval=getattr(args, "heartbeat_token_interval", 128),
         )
 
         # Write per-point JSON immediately (partial-progress preservation)
@@ -656,6 +671,17 @@ def main() -> None:
                              "invocation's grid (default 0). Used by the "
                              "per-point orchestrator so filenames carry the "
                              "correct absolute index across subprocesses.")
+    # WS-001 eval-loop instrumentation (additive 2026-05-18)
+    parser.add_argument("--enable-heartbeat", action="store_true",
+                        help="Emit JSONL heartbeat sidecar per point at "
+                             "<output_dir>/<subdir>/point_NN_b_mse_B_heartbeat.jsonl "
+                             "with fsync per line; survives SIGTRAP. Each "
+                             "heartbeat carries cumulative total_loss + "
+                             "total_scored so partial PPL is reconstructible.")
+    parser.add_argument("--heartbeat-token-interval", type=int, default=128,
+                        help="Emit heartbeat every K inner-loop tokens "
+                             "(default 128). Per-sequence boundaries always "
+                             "emit regardless.")
 
     args = parser.parse_args()
 

--- a/tools/tern_r12_sweep_orchestrator.py
+++ b/tools/tern_r12_sweep_orchestrator.py
@@ -69,7 +69,7 @@ def _build_point_argv(
     output_subdir: str,
 ) -> list[str]:
     """Build the argv for one per-point subprocess invocation."""
-    return [
+    argv = [
         python, str(SWEEP_SCRIPT),
         "--model-id", args.model_id,
         "--baseline-run-id", args.baseline_run_id,
@@ -88,6 +88,11 @@ def _build_point_argv(
         "--point-index-offset", str(point_index),
         "--skip-manifest",
     ]
+    # WS-001 eval-loop instrumentation (additive 2026-05-18)
+    if getattr(args, "enable_heartbeat", False):
+        argv += ["--enable-heartbeat",
+                 "--heartbeat-token-interval", str(args.heartbeat_token_interval)]
+    return argv
 
 
 def _read_point_json(sweep_dir: Path, point_index: int, b_mse: int) -> Optional[dict]:
@@ -315,6 +320,17 @@ def main() -> None:
                    help="Reduced-param smoke mode: b_mse=[4,2], N=2, L=128")
     p.add_argument("--python", default=None,
                    help="Python interpreter for subprocesses (default: sys.executable)")
+    # WS-001 eval-loop instrumentation (additive 2026-05-18)
+    p.add_argument("--enable-heartbeat", action="store_true",
+                   help="Per-point JSONL heartbeat sidecar (fsync per line; "
+                        "survives SIGTRAP). Filename: "
+                        "point_NN_b_mse_B_heartbeat.jsonl (excluded from "
+                        "aggregator glob via .jsonl extension). Each "
+                        "heartbeat carries cumulative total_loss + "
+                        "total_scored so partial PPL is reconstructible "
+                        "from the last fsync'd line.")
+    p.add_argument("--heartbeat-token-interval", type=int, default=128,
+                   help="Heartbeat every K inner-loop tokens (default 128)")
 
     args = p.parse_args()
 


### PR DESCRIPTION
## Preamble

This PR lands the instrumentation infrastructure designed in Phase 0; the mitigation hypothesis tested in Phase C was empirically falsified, with the three findings documented below banked as the substantive Phase C output. Intra-sequence drain — the post-falsification hypothesis refinement — is being investigated under separate scope (PR #N+1 if it succeeds within budget). PR #N is the durable diagnostic foundation; PR #N+1 is the mitigation candidate built on top.

## Summary

Per-K-token heartbeat sidecar (JSONL with `fsync` per line, survives SIGTRAP) + per-sequence boundary lines for the R7-B autoregressive PPL eval loop. Each heartbeat carries cumulative `total_loss` + `total_scored` so partial PPL is reconstructible from the last fsync'd line — enabling autopsy of crashes that today's PR #36 falsification left as black boxes. Switch canonical allocator-pressure metric from `driver_allocated_memory()` to `current_allocated_memory()` per Finding 2 below. R4 aggregator-glob discipline pinned by two new tests so heartbeat sidecars (.jsonl) coexist safely with per-point JSONs (.json).

## Components

| File | Change | LOC |
|---|---|---|
| `tools/tern_ppl_bench.py` | +heartbeat infrastructure (`_mps_alloc_mb`, `_emit_heartbeat`), +per-K-token + per-sequence boundary heartbeats with cumulative loss state, +optional `heartbeat_sidecar_path` / `heartbeat_token_interval` kwargs | +194 / −20 |
| `tools/tern_r12_sweep.py` | +`--enable-heartbeat`, +`--heartbeat-token-interval` CLI; per-point sidecar path computed as `point_NN_b_mse_B_heartbeat.jsonl` | +26 / −0 |
| `tools/tern_r12_sweep_orchestrator.py` | +`--enable-heartbeat`, +`--heartbeat-token-interval`; passes through to subprocess argv | +13 / −5 |
| `tests/test_r12_sweep_aggregate.py` | +2 R4 tests (heartbeat-glob safety + .json-vs-.jsonl extension load-bearing) | +67 / −0 |

Net: **+300 / −33** across 4 files.

## Phase C R1 findings (the substantive diagnostic output)

R1 ran the canonical β1a hook at N=4 L=2048 MPS on TinyLlama-1.1B with `PYTORCH_MPS_LOW_WATERMARK_RATIO=0.0` set in the process environment. The process trapped mid-seq-0 at the same libdispatch reentrant dispatch_sync signature as PR #36's falsification and yesterday's PID 8767 (Problem Report at `~/Library/Logs/DiagnosticReports/Python-2026-05-18-121242.ips`).

The instrumentation captured what mattered:

| t in seq-0 | `driver_allocated_memory()` MB |
|---|---|
| 128 | 3,331 |
| 256 | 5,387 |
| 384 | 9,483 |
| 512 | 14,604 |
| 768 | 28,940 |
| 1024 | 49,420 |
| 1280 | 76,044 |
| **1408** | **8,244** ← `release_cached_buffers` fired (cache release without trap) |
| 1536 | 50,780 |
| **1664** | **11,748** ← fired again (no trap) |
| 1792 | 89,620 |
| 1920 | 85,181 |
| [TRAP] | — |

Three findings that contradict the briefed mitigation hypothesis:

### Finding 1 — `PYTORCH_MPS_LOW_WATERMARK_RATIO=0.0` does NOT prevent `release_cached_buffers` from firing

The doc string ([PyTorch MPS env-var docs](https://docs.pytorch.org/docs/stable/mps_environment_variables.html)) promises "disables adaptive commit and garbage collection." Empirics show two distinct cache-release events (t=1408 and t=1664) WITH the env var set. The env var either disables only one path to `release_cached_buffers`, OR is read too late despite being set in `os.environ` before Python starts, OR overstates the effect. Necessary-but-insufficient at best; possibly irrelevant. Env-var plumbing dropped from this PR.

### Finding 2 — `torch.mps.driver_allocated_memory()` is unreliable on unified memory

The metric reports >76 GB on a 64 GB M4 Pro — physically impossible as resident memory. Likely reports virtual-address-space commitments, not physical residency. Switching to `torch.mps.current_allocated_memory()` (PyTorch allocator's view of in-use bytes) as the canonical heartbeat metric.

### Finding 3 — The trap fires inside a single sequence's forward-pass loop, not at sequence boundaries

Yesterday's PID 8767 ~87 min wall-time was sequence-0 wall-time at canonical L=2048 single-process. Trap fires around forward 1920-2048. Which sequence the trap hits depends on prior allocator state. **Critically: a between-sequence drain cannot help if the trap fires within a sequence.** This re-frames the mitigation hypothesis from "between-sequence drain" to "intra-sequence drain" (under separate investigation).

## Design notes

**Numerical-neutrality:** heartbeat instrumentation is counter reads only (`current_allocated_memory()`, `time.perf_counter()`, `utc_now_iso()`). No kernel launches, no dispatch_sync, no MPS→CPU sync points added. The eval's existing `loss.item()` is untouched.

**Survival under SIGTRAP:** every heartbeat line is `f.write(line); f.flush(); os.fsync(f.fileno())`. The kernel commits the durable record before the next forward executes. Today's R1 trap demonstrated this: the heartbeat file captured the full alloc-MB trajectory up to the trap, even as stdout lost the last buffered seconds.

**Cumulative loss in heartbeats:** every heartbeat carries `total_loss` + `total_scored` so `ppl_partial = exp(total_loss / total_scored)` is reconstructible from the last surviving line. Future trap autopsy gets partial PPL recovery without process re-run.

**R4 aggregator-glob discipline:** aggregator's `sweep_dir.glob("point_*.json")` + regex `^point_(\d+)_b_mse_(\d+)_.*\.json$` both require literal `.json` extension. Heartbeat sidecars use `.jsonl`. Two tests pin this:
- Positive: sidecar in dir, aggregator ignores, manifest correct.
- Negative: if sidecar misnamed `.json` (no `L`), regex matches and `json.loads` on JSONL raises — documents WHY `.jsonl` is load-bearing.

## What's NOT in this PR

- Per-sequence drain (`torch.mps.empty_cache()` between sequences) — Finding 3 falsified this approach; dropped from scope.
- `PYTORCH_MPS_LOW_WATERMARK_RATIO=0.0` env-var plumbing — Finding 1 falsified the env-var alone; dropped from scope.
- `--canonical-mitigation` shorthand — built on a falsified hypothesis; dropped.
- Verification scripts (`r12_r1_numerical_neutrality.py`, `r12_smoke_a_4arm.py`) — written speculatively for the falsified hypothesis; deleted from this PR. R1' re-gate and Smoke A' for the intra-sequence-drain candidate live in PR #N+1's scope.

## Test plan

- [x] `pytest tests/test_r12_sweep_aggregate.py -v` → 16/16 PASS in 0.7s (14 existing + 2 new R4 tests).
- [x] Import smoke: all four tools modules import cleanly.
- [x] `--help` smoke: orchestrator + sweep CLI flags surface cleanly.
- [x] R1 instrumentation real-run: captured 16+ heartbeat lines before SIGTRAP; cumulative-loss-equipped successor sidecar will enable partial-PPL recovery for the next crash.

## Falsifiability (reframed)

This PR makes no mitigation claim. The instrumentation's falsifier statement is observability-level:
- If a future SIGTRAP occurs and the heartbeat sidecar is empty / missing the trap-adjacent window → fsync discipline is wrong; revise.
- If `current_allocated_memory()` returns implausible values (e.g., negative, or >physical RAM) → metric switch needs revisiting.

For mitigation falsifiability, see PR #N+1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)