### PR TITLE
ci(test): bump checkout v4→v6, setup-python v5→v6 (Node 20 → Node 24)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,9 +12,9 @@ jobs:
       matrix:
         python-version: ["3.11"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -22,7 +22,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e ".[dev,transformers]"
       - name: Checkout integration3 (canonical pin)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: gamma-seeds/integration3
           ref: v1.0.3


### PR DESCRIPTION
## Summary

- Mirror of integration3 PR #5 ([f892e37](https://github.com/gamma-seeds/integration3/commit/f892e37af6cfd4f4e17058f9fa5d273d3dd33e9b))
- Clears the Node 20 deprecation warning surfaced on every tern-core CI run:

> `##[warning]Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4, actions/setup-python@v5. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026.`

- Three pin updates in `.github/workflows/test.yml`:
  - `actions/checkout@v4` → `v6` (main repo checkout, line 15)
  - `actions/setup-python@v5` → `v6` (line 17)
  - `actions/checkout@v4` → `v6` (integration3 canonical pin checkout, line 25)

Both bumped pins (`actions/checkout` v6.0.2 / `actions/setup-python` v6.2.0) run on Node 24, ahead of the 2 June 2026 forced cutover and the 16 September 2026 Node 20 removal.

## Test plan

- [ ] CI test (3.11) green
- [ ] Integration3 checkout/install steps still pass (token-gated step verified)
- [ ] C kernel build + pytest + C tests all green
- [ ] Node 20 deprecation warning gone from PR run logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)