### PR TITLE
feat(moe): ternary expert bank loader for per-expert MoE manifests (M1 Stage 1)

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -121,8 +121,29 @@ Original criterion ("All 5 manifests load") was written without M4 Pro 64 GB fac
 
 ### load_packed_model: MoE per-expert restacking for stacked-tensor architectures
 
-**Status:** Open (medium priority, natural integration with L5 sprint planned for week of 2026-05-12)
+**Status:** Partially resolved 2026-05-28 — Milestone 1 Stage 1 (Qwen3-30B-A3B via expert bank). Gemma-4 stacked-tensor case + the dense-into-HF-model path remain open.
 **Surfaced:** 2026-05-08 by gemma4-26b-a4b production manifest integration retest during PR #18 verification
+
+**Stage-1 resolution (2026-05-28, branch `feat/moe-expert-bank-loader-2026-05-28`):**
+The Milestone-1 architecture took Direction B — keep experts ternary-resident
+rather than restack them dense into the transformers fused-experts Parameter.
+`terncore.moe.load_moe_packed` routes per-expert entries into a
+`PackedTernaryExpertBank` addressable by `(layer, expert, proj)`; attention
+loads as `PackedTernaryLinear`; norms/router/embeddings/LM head load as
+protected dense tensors. Verified on the real Qwen3-30B-A3B artefact:
+18,867/18,867 entries routed (18,432 expert + 192 attention + 243 protected),
+exact reconstruction fidelity, **peak RSS 13.27 GB** (vs ~57 GB for the dense
+HF-mutation path that made the Qwen3 integration test skip). `load_packed_model`
+now raises a loud, actionable `ValueError` on per-expert MoE manifests directing
+callers to `load_moe_packed`.
+
+**Still open:** (a) Gemma-4-26B-A4B uses 3-D stacked manifest slices (`stacked_parent`
+metadata) + fuses gate+up differently — a second routing path in `load_moe_packed`;
+(b) the dense-restack-into-stock-HF-model variant (only relevant on 128+ GB hardware
+or for non-streaming use). The Stage 3 custom MoE block (router → bank dispatch) is
+the consumer that turns the bank into a runnable model.
+
+**Original framing (retained):**
 
 **Observation:** PR #14's per-expert slicing rework produces compressed manifests with 128 separate `experts.N.{gate,up,down}_proj.weight` entries per layer (Gemma 4 family) for per-expert sparsity measurement granularity. PR #18's `load_packed_model` rewrite handles per-entry dispatch (one entry → one module replacement or parameter assignment). The intersection — loading per-expert-sliced MoE manifests back into HF MoE models that expose experts as stacked-tensor Parameters (e.g., `model.language_model.layers.0.experts.gate_up_proj` with first dim = 128) rather than ModuleList of individual expert modules — was never empirically tested before 2026-05-08's gemma4-26b-a4b retest.
 

--- a/src/terncore/moe/__init__.py
+++ b/src/terncore/moe/__init__.py
@@ -1,0 +1,26 @@
+"""
+Ternary Mixture-of-Experts inference primitives.
+
+Milestone 1 (resident sparse-MoE inference): the experts of an MoE model
+are held as addressable, ternary-resident ``PackedTernaryLinear`` modules
+in a :class:`PackedTernaryExpertBank` rather than materialised dense into
+the transformers fused-experts Parameter. This keeps Qwen3-30B-A3B's
+18,432 expert weights at ~7.5 GB packed instead of ~57 GB FP16, fitting
+the M4 Pro 64 GB unified-memory envelope, and provides the substrate the
+Stage 3 custom MoE block routes through (P145 indexing-vector-conditional
+firing; P146 prepare-and-launch dispatch).
+
+Copyright (c) 2025-2026 Gamma Seeds Pte Ltd. All rights reserved.
+"""
+
+from terncore.moe.expert_bank import (
+    MoEPackedModel,
+    PackedTernaryExpertBank,
+    load_moe_packed,
+)
+
+__all__ = [
+    "PackedTernaryExpertBank",
+    "MoEPackedModel",
+    "load_moe_packed",
+]

--- a/src/terncore/moe/expert_bank.py
+++ b/src/terncore/moe/expert_bank.py
@@ -1,0 +1,361 @@
+"""
+Ternary MoE expert bank and packed-MoE loader — Milestone 1 Stage 1.
+
+Per-expert-sliced ``.tern-model`` manifests (Qwen3-30B-A3B,
+Gemma-4-26B-A4B) store experts as separate ternary tensors
+(``model.layers.{L}.mlp.experts.{E}.{gate,up,down}_proj.weight``). The
+transformers 5.5+ runtime, however, exposes MoE experts as *fused stacked
+Parameters* (``Qwen3MoeExperts.gate_up_proj`` shape
+``[num_experts, 2*moe_intermediate, hidden]`` and ``down_proj`` shape
+``[num_experts, hidden, moe_intermediate]``) with no per-expert submodule.
+Loading the manifest into that fused Parameter would require dense
+materialisation (~57 GB FP16 for Qwen3-30B-A3B) — busting the M4 Pro
+64 GB ceiling and discarding the ternary memory win.
+
+:func:`load_moe_packed` instead routes per-expert weights into a
+:class:`PackedTernaryExpertBank`, addressable by ``(layer, expert, proj)``,
+keeping experts ternary-resident (~7.5 GB). Attention projections load as
+``PackedTernaryLinear`` (ternary); norms, router, embeddings and LM head
+load as protected dense tensors. The bank is the substrate the Stage 3
+custom MoE block routes through:
+
+    router top-k  →  Index³ indexing vector  →  bank.get(layer, expert, proj)
+                  →  ternary matmul (Metal kernel, PR #9)  →  gate-weighted combine
+
+mapping P145's multi-controlled-operation / indexing-vector-conditional
+firing pattern onto MoE inference, dispatched across the P146
+prepare-and-launch boundary.
+
+Copyright (c) 2025-2026 Gamma Seeds Pte Ltd. All rights reserved.
+"""
+
+from __future__ import annotations
+
+import re
+import time
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Tuple
+
+import torch
+import torch.nn as nn
+
+# Manifest entry name patterns (Qwen3 / Gemma-4 MoE convention).
+_EXPERT_RE = re.compile(
+    r"\.layers\.(?P<layer>\d+)\.mlp\.experts\.(?P<expert>\d+)\."
+    r"(?P<proj>gate|up|down)_proj\.weight$"
+)
+_ATTENTION_RE = re.compile(
+    r"\.layers\.(?P<layer>\d+)\.self_attn\.(?P<qkvo>q|k|v|o)_proj\.weight$"
+)
+_LAYER_RE = re.compile(r"\.layers\.(\d+)\.")
+
+_PROJECTIONS = ("gate", "up", "down")
+
+
+def _layer_of(name: str) -> Optional[int]:
+    """Return the transformer block index in ``name``, or None if global."""
+    m = _LAYER_RE.search(name)
+    return int(m.group(1)) if m else None
+
+
+def _module_bytes(module: nn.Module) -> int:
+    """Total bytes held by a module's parameters + buffers."""
+    total = 0
+    for t in list(module.parameters()) + list(module.buffers()):
+        total += t.numel() * t.element_size()
+    return total
+
+
+class PackedTernaryExpertBank(nn.Module):
+    """Addressable, ternary-resident store of MoE expert weights.
+
+    Experts are keyed by ``(layer_idx, expert_idx, projection)`` where
+    ``projection`` is one of ``"gate"``, ``"up"``, ``"down"``. Each entry
+    is a :class:`~terncore.packed_linear.PackedTernaryLinear` holding 2-bit
+    packed weights (no dense materialisation). Backed by an
+    ``nn.ModuleDict`` so the whole bank moves with ``.to(device)`` and is
+    visible to ``state_dict`` / parameter introspection.
+
+    The Stage 3 custom MoE block consumes :meth:`get` per selected expert;
+    Milestone 2 attaches the SURE/UNSURE/UNKNOWN lifecycle on top.
+    """
+
+    def __init__(
+        self,
+        num_experts: Optional[int] = None,
+        num_layers: Optional[int] = None,
+    ) -> None:
+        super().__init__()
+        # nn.ModuleDict keys may not contain '.', so encode the tuple key.
+        self._experts = nn.ModuleDict()
+        self.num_experts = num_experts
+        self.num_layers = num_layers
+
+    @staticmethod
+    def _key(layer: int, expert: int, proj: str) -> str:
+        if proj not in _PROJECTIONS:
+            raise ValueError(
+                f"projection must be one of {_PROJECTIONS}, got {proj!r}"
+            )
+        return f"L{layer}_E{expert}_{proj}"
+
+    def add(self, layer: int, expert: int, proj: str, module: nn.Module) -> None:
+        key = self._key(layer, expert, proj)
+        if key in self._experts:
+            raise ValueError(
+                f"Duplicate expert entry for (layer={layer}, expert={expert}, "
+                f"proj={proj!r}) — manifest contains the same expert twice."
+            )
+        self._experts[key] = module
+
+    def get(self, layer: int, expert: int, proj: str) -> nn.Module:
+        return self._experts[self._key(layer, expert, proj)]
+
+    def has(self, layer: int, expert: int, proj: str) -> bool:
+        return self._key(layer, expert, proj) in self._experts
+
+    def __len__(self) -> int:
+        return len(self._experts)
+
+    def layers(self) -> List[int]:
+        seen = set()
+        for key in self._experts:
+            seen.add(int(key.split("_", 1)[0][1:]))  # "L{n}"
+        return sorted(seen)
+
+    def experts_in_layer(self, layer: int) -> List[int]:
+        seen = set()
+        prefix = f"L{layer}_E"
+        for key in self._experts:
+            if key.startswith(prefix):
+                # key = L{layer}_E{expert}_{proj}
+                seen.add(int(key.split("_E", 1)[1].split("_", 1)[0]))
+        return sorted(seen)
+
+    def nbytes(self) -> int:
+        return sum(_module_bytes(m) for m in self._experts.values())
+
+
+@dataclass
+class MoEPackedModel:
+    """Components of a packed MoE model, loaded from a ``.tern-model``.
+
+    Stage 1 deliverable — the addressable building blocks. Stage 3 assembles
+    these into a runnable model: the protected tensors and attention modules
+    populate a Qwen3 skeleton, and a custom ``Qwen3MoeSparseMoeBlock``
+    replacement routes through :attr:`bank`.
+
+    Attributes:
+        bank:       per-expert ternary weights, addressable by
+                    ``(layer, expert, proj)``.
+        attention:  per-(layer, "q"|"k"|"v"|"o") ternary projections.
+        protected:  dense tensors keyed by manifest name (norms, router
+                    ``mlp.gate.weight``, ``embed_tokens``, ``lm_head``,
+                    q/k norms). Reconstructed from FP16/INT4 entries.
+        metadata:   inferred shapes/counts (hidden, moe_intermediate, …).
+        coverage:   per-category routing counts + verification results.
+    """
+
+    bank: PackedTernaryExpertBank
+    attention: Dict[Tuple[int, str], nn.Module]
+    protected: Dict[str, torch.Tensor]
+    metadata: Dict[str, object] = field(default_factory=dict)
+    coverage: Dict[str, object] = field(default_factory=dict)
+
+    def nbytes(self) -> int:
+        b = self.bank.nbytes()
+        b += sum(_module_bytes(m) for m in self.attention.values())
+        b += sum(t.numel() * t.element_size() for t in self.protected.values())
+        return b
+
+    def summary_str(self) -> str:
+        c = self.coverage
+        gb = self.nbytes() / (1024 ** 3)
+        lines = [
+            "MoEPackedModel:",
+            f"  experts (bank):   {c.get('expert_entries', 0):>6}  "
+            f"({len(self.bank.layers())} layers)",
+            f"  attention:        {c.get('attention_entries', 0):>6}",
+            f"  protected (dense):{c.get('protected_entries', 0):>6}",
+            f"  skipped (limit):  {c.get('skipped_entries', 0):>6}",
+            f"  total routed:     {c.get('routed_entries', 0):>6} / "
+            f"{c.get('total_entries', 0)}",
+            f"  resident size:    {gb:.2f} GB",
+            f"  hidden={self.metadata.get('hidden')}  "
+            f"moe_intermediate={self.metadata.get('moe_intermediate')}  "
+            f"num_experts={self.metadata.get('num_experts')}",
+        ]
+        return "\n".join(lines)
+
+
+def load_moe_packed(
+    reader,
+    *,
+    limit_layers: Optional[int] = None,
+    spot_check_n: int = 4,
+    verbose: bool = False,
+):
+    """Load a per-expert-sliced MoE ``.tern-model`` into a packed structure.
+
+    Routes manifest entries by name/dtype:
+
+    - ``...mlp.experts.{E}.{gate,up,down}_proj.weight`` (ternary2) → bank
+    - ``...self_attn.{q,k,v,o}_proj.weight`` (ternary2) → attention
+    - everything else (FP16 norms/router/embeddings/LM head, INT4) →
+      protected dense tensors
+
+    Experts and attention stay packed (``PackedTernaryLinear``); only the
+    protected entries materialise dense. The 57 GB FP16 base is never
+    loaded — the manifest covers 100% of parameters.
+
+    Args:
+        reader:        a ``TernModelReader`` over the artefact.
+        limit_layers:  if set, only load transformer blocks with index
+                       ``< limit_layers`` (global entries always load).
+                       Bounds memory/time for smoke runs.
+        spot_check_n:  number of expert entries to verify by independent
+                       dense reconstruction (shape + finite alpha + sparsity
+                       within tolerance of the manifest).
+        verbose:       print a progress heartbeat every 2000 entries.
+
+    Returns:
+        :class:`MoEPackedModel`.
+
+    Raises:
+        ValueError: if a ternary entry matches neither the expert nor the
+            attention pattern (unexpected for a known MoE architecture), or
+            if no per-expert entries are present (not an MoE manifest).
+    """
+    layers = reader.manifest["layers"]
+    if not any(_EXPERT_RE.search(e["name"]) for e in layers):
+        raise ValueError(
+            "No per-expert entries ('...mlp.experts.N....') found in manifest "
+            "— this does not look like a per-expert-sliced MoE artefact. "
+            "Use TernModelReader.load_packed_model for dense models."
+        )
+
+    bank = PackedTernaryExpertBank()
+    attention: Dict[Tuple[int, str], nn.Module] = {}
+    protected: Dict[str, torch.Tensor] = {}
+
+    expert_n = attn_n = protected_n = skipped_n = 0
+    max_layer = -1
+    max_expert = -1
+    hidden = moe_intermediate = None
+    t0 = time.perf_counter()
+
+    for i, entry in enumerate(layers):
+        name = entry["name"]
+        dtype = entry["dtype"]
+        layer = _layer_of(name)
+        if limit_layers is not None and layer is not None and layer >= limit_layers:
+            skipped_n += 1
+            continue
+
+        m = _EXPERT_RE.search(name)
+        if m:
+            if dtype != "ternary2":
+                raise ValueError(
+                    f"Expert weight {name!r} expected ternary2, got {dtype!r}."
+                )
+            L = int(m.group("layer"))
+            E = int(m.group("expert"))
+            proj = m.group("proj")
+            bank.add(L, E, proj, reader.build_packed_linear(name))
+            expert_n += 1
+            max_layer = max(max_layer, L)
+            max_expert = max(max_expert, E)
+            # Infer shapes from a gate/up (out=moe_intermediate, in=hidden).
+            if proj in ("gate", "up") and hidden is None:
+                moe_intermediate, hidden = entry["shape"][0], entry["shape"][1]
+            continue
+
+        a = _ATTENTION_RE.search(name)
+        if a and dtype == "ternary2":
+            L = int(a.group("layer"))
+            attention[(L, a.group("qkvo"))] = reader.build_packed_linear(name)
+            attn_n += 1
+            max_layer = max(max_layer, L)
+            continue
+
+        if dtype == "ternary2":
+            raise ValueError(
+                f"Ternary entry {name!r} matched neither the expert nor the "
+                f"attention pattern. Unexpected for a known MoE architecture "
+                f"— extend load_moe_packed's routing if this is intended."
+            )
+
+        # Protected: FP16 (norms, router, embeddings, LM head) or INT4.
+        recon = reader.reconstruct_layer(name)
+        protected[name] = recon["weight"]
+        if "bias" in recon:
+            protected[f"{name}::bias"] = recon["bias"]
+        protected_n += 1
+
+        if verbose and (i % 2000 == 0) and i:
+            print(
+                f"  …{i}/{len(layers)} entries "
+                f"({time.perf_counter() - t0:.0f}s)",
+                flush=True,
+            )
+
+    bank.num_experts = (max_expert + 1) if max_expert >= 0 else None
+    bank.num_layers = (max_layer + 1) if max_layer >= 0 else None
+
+    # Independent fidelity spot-check on a spread of expert entries.
+    spot_checks: List[dict] = []
+    if spot_check_n > 0:
+        expert_names = [
+            e["name"] for e in layers
+            if _EXPERT_RE.search(e["name"])
+            and not (
+                limit_layers is not None
+                and (_layer_of(e["name"]) or 0) >= limit_layers
+            )
+        ]
+        if expert_names:
+            step = max(1, len(expert_names) // spot_check_n)
+            for name in expert_names[:: step][:spot_check_n]:
+                entry = reader._get_manifest_entry(name)
+                dense = reader.reconstruct_layer(name)["weight"]
+                sparsity = float((dense == 0).float().mean())
+                spot_checks.append(
+                    {
+                        "name": name,
+                        "shape_ok": list(dense.shape) == list(entry["shape"]),
+                        "finite": bool(torch.isfinite(dense).all()),
+                        "alpha": entry.get("alpha"),
+                        "sparsity_observed": round(sparsity, 4),
+                        "sparsity_manifest": round(entry.get("sparsity", -1), 4),
+                        "sparsity_within_tol": abs(
+                            sparsity - entry.get("sparsity", -1)
+                        ) < 0.02,
+                    }
+                )
+
+    coverage = {
+        "total_entries": len(layers),
+        "expert_entries": expert_n,
+        "attention_entries": attn_n,
+        "protected_entries": protected_n,
+        "skipped_entries": skipped_n,
+        "routed_entries": expert_n + attn_n + protected_n,
+        "load_seconds": round(time.perf_counter() - t0, 1),
+        "spot_checks": spot_checks,
+    }
+    metadata = {
+        "hidden": hidden,
+        "moe_intermediate": moe_intermediate,
+        "num_experts": bank.num_experts,
+        "num_layers": bank.num_layers,
+        "source": reader.manifest.get("model_metadata", {}).get("source"),
+        "adapter": reader.manifest.get("model_metadata", {}).get("adapter"),
+    }
+
+    return MoEPackedModel(
+        bank=bank,
+        attention=attention,
+        protected=protected,
+        metadata=metadata,
+        coverage=coverage,
+    )

--- a/src/terncore/tern_model.py
+++ b/src/terncore/tern_model.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import io
 import json
 import logging
+import re
 import struct
 import time
 import zlib
@@ -86,6 +87,11 @@ _PRODUCTION_NAME_SUFFIXES = (
     ".std_bias", ".std_scale",
     ".position_embedding_table",
 )
+
+# Per-expert manifest entry marker (e.g. ``...mlp.experts.7.gate_proj.weight``).
+# Used by load_packed_model to detect MoE manifests it cannot load via
+# submodule replacement and redirect to terncore.moe.load_moe_packed.
+_EXPERT_ENTRY_RE = re.compile(r"\.experts\.\d+\.")
 
 
 def _resolve_param_path(name: str) -> Tuple[str, Optional[str]]:
@@ -1161,6 +1167,56 @@ class TernModelReader:
                 return entry
         raise KeyError(f"Layer {layer_name!r} not found in manifest")
 
+    def build_packed_linear(self, name: str) -> "nn.Module":
+        """Build a ``PackedTernaryLinear`` for a single ``ternary2`` entry.
+
+        Fast path — no re-quantisation; the packed 2-bit bytes from file
+        are used directly. Byte layout matches ``load_packed_model``'s
+        ternary branch: alpha (f32) → packed_size (u32) + packed bytes →
+        bitmap_size (u32) + bitmap → bias_size (u32) + bias.
+
+        Shared by the MoE expert-bank loader
+        (``terncore.moe.load_moe_packed``), which keeps per-expert weights
+        ternary-resident as addressable modules rather than materialising
+        them dense into a transformers fused-experts Parameter.
+
+        Raises ``ValueError`` if the entry is not ``ternary2``.
+        """
+        from terncore.packed_linear import PackedTernaryLinear
+
+        entry = self._get_manifest_entry(name)
+        if entry["dtype"] != "ternary2":
+            raise ValueError(
+                f"build_packed_linear requires a 'ternary2' entry; "
+                f"{name!r} is {entry['dtype']!r}."
+            )
+        buf = io.BytesIO(self.read_layer_data(name))
+        alpha = struct.unpack("<f", buf.read(4))[0]
+        packed_size = struct.unpack("<I", buf.read(4))[0]
+        packed_tensor = torch.frombuffer(
+            bytearray(buf.read(packed_size)), dtype=torch.uint8
+        ).clone()
+        bitmap_size = struct.unpack("<I", buf.read(4))[0]
+        bitmap_tensor = None
+        if bitmap_size > 0:
+            bitmap_tensor = torch.frombuffer(
+                bytearray(buf.read(bitmap_size)), dtype=torch.uint8
+            ).clone()
+        bias_size = struct.unpack("<I", buf.read(4))[0]
+        bias = None
+        if bias_size > 0:
+            bias = torch.frombuffer(
+                bytearray(buf.read(bias_size)), dtype=torch.float32
+            ).clone()
+        return PackedTernaryLinear.from_packed_data(
+            packed_weights=packed_tensor,
+            alpha=alpha,
+            in_features=entry["shape"][1],
+            out_features=entry["shape"][0],
+            bias=bias,
+            sparsity_bitmap=bitmap_tensor,
+        )
+
     # ── Reconstruction methods ──────────────────────────────────
 
     def reconstruct_layer(self, name: str) -> dict[str, torch.Tensor]:
@@ -1593,6 +1649,27 @@ class TernModelReader:
         loaded_keys: list[str] = []
         model_keys = set(dict(model.named_parameters()).keys())
         model_keys.update(dict(model.named_buffers()).keys())
+
+        # MoE per-expert manifest guard. Per-expert-sliced manifests
+        # (entries matching ``.experts.N.``, e.g. Qwen3-30B-A3B,
+        # Gemma-4-26B-A4B) cannot load via submodule replacement:
+        # transformers 5.5+ exposes MoE experts as fused stacked
+        # Parameters (``Qwen3MoeExperts.gate_up_proj`` /  ``down_proj``
+        # with first dim = num_experts), which have no per-expert
+        # submodule to replace. Loud, actionable failure pointing at the
+        # bank loader rather than the cryptic ``has no attribute '0'``
+        # AttributeError on the first ``experts.0`` lookup.
+        if any(_EXPERT_ENTRY_RE.search(e["name"]) for e in self.manifest["layers"]):
+            raise ValueError(
+                "Per-expert-sliced MoE manifest detected (entries match "
+                "'.experts.N.'). load_packed_model performs submodule "
+                "replacement, but transformers 5.5+ exposes MoE experts as "
+                "fused stacked Parameters with no per-expert submodule. Use "
+                "terncore.moe.load_moe_packed(reader, ...) — it builds a "
+                "PackedTernaryExpertBank keeping experts ternary-resident. "
+                "See docs/backlog.md 'load_packed_model: MoE per-expert "
+                "restacking for stacked-tensor architectures'."
+            )
 
         # Per-call counter for INT4 entries — drives the operator-visible
         # log message (one-shot per load_packed_model invocation, not a

--- a/tests/test_load_packed_model_production_integration.py
+++ b/tests/test_load_packed_model_production_integration.py
@@ -105,21 +105,16 @@ IN_SCOPE_MANIFESTS = [
         id="gemma4-26b-a4b",
         marks=pytest.mark.xfail(
             reason=(
-                "Per-expert-sliced MoE manifests require restacking logic "
-                "in load_packed_model that's not yet implemented. PR #14's "
-                "per-expert slicing produces 128 separate experts.N.weight "
-                "entries per layer (for measurement granularity); HF "
-                "Gemma-4-26B-A4B-it exposes experts as stacked tensors "
-                "(experts.gate_up_proj, experts.down_proj with first dim = 128). "
-                "load_packed_model walks per-entry expecting separate modules; "
-                "_resolve_module_or_raise correctly raises ValueError on the "
-                "first 'experts.0' lookup since experts is a stacked-tensor "
-                "Parameter, not a ModuleList. Banked as backlog item: "
-                "'load_packed_model: MoE per-expert restacking for "
-                "stacked-tensor architectures' (cf. docs/backlog.md). "
-                "Scheduled for next-week L5 sprint where MoE expert paging "
-                "is the primary engineering scope; restacking is a natural "
-                "prerequisite for the demand-paging work."
+                "MoE manifests do not load via load_packed_model (submodule "
+                "replacement) because transformers 5.5+ exposes experts as "
+                "fused stacked Parameters with no per-expert submodule. As of "
+                "2026-05-28 load_packed_model raises a loud ValueError on "
+                "per-expert manifests directing to terncore.moe.load_moe_packed, "
+                "which keeps experts ternary-resident in a PackedTernaryExpertBank "
+                "(Milestone 1 Stage 1, verified on Qwen3-30B-A3B). The Gemma-4 "
+                "stacked-tensor routing path within load_moe_packed is still open "
+                "(cf. docs/backlog.md 'load_packed_model: MoE per-expert "
+                "restacking'); this dense-into-HF-model path stays xfail."
             ),
             strict=True,
         ),

--- a/tests/test_moe_expert_bank.py
+++ b/tests/test_moe_expert_bank.py
@@ -1,0 +1,216 @@
+"""
+Tests for the ternary MoE expert bank + packed-MoE loader (Milestone 1
+Stage 1).
+
+Fast tests build a synthetic per-expert-sliced MoE ``.tern-model`` (2
+layers × 4 experts, Qwen3-style names) and exercise the full routing,
+addressing, and forward path with no archive dependency — these run under
+the default ``pytest -m "not slow"`` gate.
+
+The slow test loads the real Qwen3-30B-A3B artefact off the archive and
+verifies 100% manifest coverage + reconstruction fidelity. Opt-in via
+``pytest -m slow``; skips cleanly when the archive is not mounted.
+
+Copyright (c) 2025-2026 Gamma Seeds Pte Ltd. All rights reserved.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import torch
+import torch.nn as nn
+
+from terncore.moe import PackedTernaryExpertBank, load_moe_packed
+from terncore.tern_model import TernModelReader, TernModelWriter
+
+# Synthetic dims (Qwen3-shaped, tiny).
+H = 16      # hidden_size
+I = 8       # moe_intermediate_size
+NL = 2      # num_hidden_layers
+NE = 4      # num_experts
+VOCAB = 32
+
+
+def _build_synthetic_moe(path: Path) -> None:
+    """Write a tiny per-expert-sliced MoE .tern-model with Qwen3 names."""
+    torch.manual_seed(1337)
+    w = TernModelWriter({"source": "synthetic-moe", "adapter": "qwen3_moe"})
+
+    for L in range(NL):
+        for E in range(NE):
+            # gate/up: [moe_intermediate, hidden]; down: [hidden, moe_intermediate]
+            w.add_layer(f"model.layers.{L}.mlp.experts.{E}.gate_proj.weight",
+                        torch.randn(I, H), dtype="ternary2")
+            w.add_layer(f"model.layers.{L}.mlp.experts.{E}.up_proj.weight",
+                        torch.randn(I, H), dtype="ternary2")
+            w.add_layer(f"model.layers.{L}.mlp.experts.{E}.down_proj.weight",
+                        torch.randn(H, I), dtype="ternary2")
+        # Attention (ternary)
+        for proj in ("q", "k", "v", "o"):
+            w.add_layer(f"model.layers.{L}.self_attn.{proj}_proj.weight",
+                        torch.randn(H, H), dtype="ternary2")
+        # Protected (FP16): norms, q/k norms, router
+        for nm in ("input_layernorm", "post_attention_layernorm"):
+            w.add_layer(f"model.layers.{L}.{nm}.weight",
+                        torch.randn(H), dtype="float16")
+        for nm in ("q_norm", "k_norm"):
+            w.add_layer(f"model.layers.{L}.self_attn.{nm}.weight",
+                        torch.randn(H), dtype="float16")
+        w.add_layer(f"model.layers.{L}.mlp.gate.weight",
+                    torch.randn(NE, H), dtype="float16")  # router
+
+    # Global protected
+    w.add_layer("model.embed_tokens.weight", torch.randn(VOCAB, H), dtype="float16")
+    w.add_layer("model.norm.weight", torch.randn(H), dtype="float16")
+    w.add_layer("lm_head.weight", torch.randn(VOCAB, H), dtype="float16")
+
+    w.write(str(path))
+
+
+@pytest.fixture()
+def synthetic_reader(tmp_path) -> TernModelReader:
+    path = tmp_path / "synthetic_moe.tern-model"
+    _build_synthetic_moe(path)
+    return TernModelReader(str(path))
+
+
+# ── Fast unit tests (synthetic) ──────────────────────────────────────
+
+
+def test_routing_counts(synthetic_reader):
+    m = load_moe_packed(synthetic_reader, spot_check_n=3)
+    c = m.coverage
+    assert c["expert_entries"] == NL * NE * 3            # 24
+    assert c["attention_entries"] == NL * 4             # 8
+    assert c["protected_entries"] == NL * 5 + 3         # 13
+    assert c["skipped_entries"] == 0
+    assert c["routed_entries"] == c["total_entries"]    # 45, full coverage
+
+
+def test_metadata_inferred(synthetic_reader):
+    m = load_moe_packed(synthetic_reader)
+    assert m.metadata["hidden"] == H
+    assert m.metadata["moe_intermediate"] == I
+    assert m.metadata["num_experts"] == NE
+    assert m.metadata["num_layers"] == NL
+
+
+def test_bank_addressing(synthetic_reader):
+    m = load_moe_packed(synthetic_reader)
+    bank = m.bank
+    assert len(bank) == NL * NE * 3
+    assert bank.layers() == [0, 1]
+    assert bank.experts_in_layer(0) == [0, 1, 2, 3]
+    assert bank.has(1, 3, "down")
+    assert not bank.has(0, 99, "gate")   # absent expert
+
+
+def test_expert_forward_is_packed_and_finite(synthetic_reader):
+    m = load_moe_packed(synthetic_reader)
+    gate = m.bank.get(0, 0, "gate")          # [I, H] linear
+    out = gate(torch.randn(2, H))
+    assert out.shape == (2, I)
+    assert torch.isfinite(out).all()
+    # Confirm it is packed (2-bit), not a dense nn.Linear.
+    assert hasattr(gate, "packed_weights")
+
+
+def test_attention_routed_as_packed(synthetic_reader):
+    m = load_moe_packed(synthetic_reader)
+    assert set(k[1] for k in m.attention) == {"q", "k", "v", "o"}
+    qproj = m.attention[(0, "q")]
+    assert hasattr(qproj, "packed_weights")
+    assert torch.isfinite(qproj(torch.randn(1, H))).all()
+
+
+def test_protected_are_dense_tensors(synthetic_reader):
+    m = load_moe_packed(synthetic_reader)
+    assert "model.embed_tokens.weight" in m.protected
+    assert "lm_head.weight" in m.protected
+    assert "model.layers.0.mlp.gate.weight" in m.protected   # router
+    embed = m.protected["model.embed_tokens.weight"]
+    assert tuple(embed.shape) == (VOCAB, H)
+    assert torch.isfinite(embed).all()
+
+
+def test_spot_check_fidelity(synthetic_reader):
+    m = load_moe_packed(synthetic_reader, spot_check_n=4)
+    checks = m.coverage["spot_checks"]
+    assert len(checks) >= 1
+    for ck in checks:
+        assert ck["shape_ok"] and ck["finite"]
+        assert ck["sparsity_within_tol"]
+
+
+def test_limit_layers_bounds_load(synthetic_reader):
+    m = load_moe_packed(synthetic_reader, limit_layers=1)
+    assert m.bank.layers() == [0]
+    assert m.coverage["expert_entries"] == NE * 3        # one layer
+    assert m.coverage["skipped_entries"] > 0
+
+
+def test_proj_key_guard():
+    bank = PackedTernaryExpertBank()
+    with pytest.raises(ValueError, match="projection must be"):
+        bank.add(0, 0, "qkv", nn.Identity())
+
+
+def test_load_packed_model_rejects_moe_manifest(synthetic_reader):
+    """Dense loader must fail loud + actionable on a per-expert MoE manifest."""
+    with pytest.raises(ValueError, match="load_moe_packed"):
+        synthetic_reader.load_packed_model(nn.Linear(H, H))
+
+
+def test_load_moe_packed_rejects_non_moe(tmp_path):
+    """Loader must reject a dense (non per-expert) manifest."""
+    w = TernModelWriter({"source": "dense"})
+    w.add_layer("model.layers.0.self_attn.q_proj.weight",
+                torch.randn(H, H), dtype="ternary2")
+    p = tmp_path / "dense.tern-model"
+    w.write(str(p))
+    with pytest.raises(ValueError, match="does not look like"):
+        load_moe_packed(TernModelReader(str(p)))
+
+
+# ── Slow integration test (real Qwen3-30B-A3B artefact) ───────────────
+
+_QWEN3_MANIFEST = (
+    "/Volumes/Syn Archive/models/compressed/qwen3-30b-a3b/"
+    "qwen3_30b_a3b_ternary_v0.1.0.tern-model/model.tern-model"
+)
+
+
+@pytest.mark.slow
+def test_qwen3_30b_a3b_full_bank_load(capsys):
+    """Load the real Qwen3-30B-A3B manifest into the bank; verify coverage.
+
+    Expert weights stay ternary-resident (~7.5 GB); no 57 GB FP16 base.
+    Skips when the archive is not mounted.
+    """
+    if not Path(_QWEN3_MANIFEST).exists():
+        pytest.skip("Qwen3-30B-A3B manifest not on disk (archive not mounted).")
+
+    reader = TernModelReader(_QWEN3_MANIFEST)
+    m = load_moe_packed(reader, spot_check_n=6, verbose=True)
+
+    c = m.coverage
+    # 48 layers × 128 experts × 3 projections = 18,432 expert weights
+    assert c["expert_entries"] == 48 * 128 * 3
+    assert c["attention_entries"] == 48 * 4          # 192
+    assert c["protected_entries"] == 243
+    assert c["skipped_entries"] == 0
+    assert c["routed_entries"] == c["total_entries"] == 18867
+
+    assert len(m.bank) == 18432
+    assert m.bank.layers() == list(range(48))
+    assert m.metadata["hidden"] == 2048
+    assert m.metadata["moe_intermediate"] == 768
+    assert m.metadata["num_experts"] == 128
+
+    for ck in c["spot_checks"]:
+        assert ck["shape_ok"] and ck["finite"] and ck["sparsity_within_tol"]
+
+    with capsys.disabled():
+        print("\n" + m.summary_str())


### PR DESCRIPTION
## Summary

Milestone 1 Stage 1 — a ternary-resident loader for per-expert-sliced MoE
`.tern-model` manifests. Makes Qwen3-30B-A3B loadable on the M4 Pro 64 GB
without the ~57 GB dense FP16 base, keeping experts ternary-resident.

## Problem

Per-expert-sliced MoE manifests (Qwen3-30B-A3B, Gemma-4-26B-A4B) store experts
as separate ternary tensors (`...mlp.experts.{E}.{gate,up,down}_proj.weight`).
But **transformers 5.5+ exposes MoE experts as fused stacked `nn.Parameter`s**
(`Qwen3MoeExperts.gate_up_proj` `[128, 1536, 2048]`, `down_proj` `[128, 2048, 768]`)
with **no per-expert submodule**. `load_packed_model` does submodule replacement,
so it raised a cryptic `AttributeError: Qwen3MoeExperts has no attribute '0'`.
Assigning into the fused Parameter would also force dense materialisation
(~57 GB FP16) — busting the 64 GB ceiling and discarding the ternary memory win.

This is the same wall Gemma-4 hits (the existing strict-xfail), confirmed live.

## Approach (Direction B — ternary-resident)

- **`terncore.moe.PackedTernaryExpertBank`** — experts addressable by
  `(layer, expert, proj)`, held as `PackedTernaryLinear` (2-bit packed) in an
  `nn.ModuleDict`. Substrate for the Stage 2+3 custom MoE block.
- **`terncore.moe.load_moe_packed`** — routes per-expert → bank, attention →
  ternary, norms/router/embeddings/LM head → protected dense. Manifest covers
  100% of params, so the FP16 base is never loaded.
- **`TernModelReader.build_packed_linear`** — single-entry packed reconstruction
  (shared fast path; no re-quantisation).
- **`load_packed_model` guard** — loud, actionable `ValueError` on per-expert
  MoE manifests directing to `load_moe_packed` (replaces the cryptic AttributeError).

## Verification — real Qwen3-30B-A3B artefact

| Metric | Result |
|---|---|
| Entries routed | **18,867 / 18,867** (18,432 expert + 192 attn + 243 protected), 0 skipped |
| Bank | 18,432 modules, all 48 layers |
| **Peak RSS** | **13.27 GB** (vs ~57 GB dense) — fits 64 GB |
| Fidelity | exact on every spot-check (observed sparsity == manifest to 4 dp) |
| Load time | 100 s off the archive |

## Tests

- `tests/test_moe_expert_bank.py` — 11 fast synthetic tests (routing counts,
  addressing, packed forward, fidelity spot-check, `limit_layers`, MoE-guard,
  non-MoE rejection) + 1 slow real-artefact test (skips when archive unmounted).
- Full fast suite: **590 passed, 0 regressions** (dense-load + restacking included).

## Scope / deferred

- Gemma-4-26B-A4B (3-D stacked slices + gate/up fusion) is a second routing path
  in `load_moe_packed` — still open; its strict-xfail integration test stays xfail.
- The dense-restack-into-stock-HF-model variant (128+ GB hardware) stays deferred.
- Stage 1 acceptance is structural (coverage + fidelity); generative forward lands
  in Stage 2+3 (custom `Qwen3MoeSparseMoeBlock`: router → top-k indexing vector
  (P145) → bank dispatch → ternary Metal matmul → gate-weighted combine (P146)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)