### PR TITLE
feat(moe): Expert Lifecycle Component — SURE-only (M1 Stage 4)

### DIFF
--- a/src/terncore/moe/__init__.py
+++ b/src/terncore/moe/__init__.py
@@ -18,6 +18,7 @@ from terncore.moe.expert_bank import (
     PackedTernaryExpertBank,
     load_moe_packed,
 )
+from terncore.moe.lifecycle import ConfidenceState, ExpertLifecycle
 from terncore.moe.runnable import TernaryMoEBlock, build_runnable_qwen3_moe
 
 __all__ = [
@@ -26,4 +27,6 @@ __all__ = [
     "load_moe_packed",
     "TernaryMoEBlock",
     "build_runnable_qwen3_moe",
+    "ConfidenceState",
+    "ExpertLifecycle",
 ]

--- a/src/terncore/moe/lifecycle.py
+++ b/src/terncore/moe/lifecycle.py
@@ -1,0 +1,87 @@
+"""
+Expert lifecycle — Milestone 1 Stage 4 (SURE-only).
+
+The :class:`ExpertLifecycle` sits *beside* the
+:class:`~terncore.moe.expert_bank.PackedTernaryExpertBank` (not inside the
+scheduler or the model registry) and is the attach point for P145's
+confidence-stratified controlled-operation pattern, mapped onto expert
+memory residency:
+
+    SURE     resident in unified memory — fire immediately
+    UNSURE   manifest-known, pageable on selection      (Milestone 2)
+    UNKNOWN  cold on disk, not yet touched              (Milestone 2)
+
+In Milestone 1 every expert the bank holds is SURE; :meth:`prepare` (the
+P146 "prepare" phase) is therefore a no-op that simply asserts residency.
+This class deliberately implements **neither** the UNSURE/UNKNOWN
+transitions nor a demand-pager — those are Milestone 2, where a subclass
+overrides :meth:`prepare` to page an expert in (UNKNOWN/UNSURE → SURE) and
+adds cache/eviction transitions (SURE → UNSURE). The interface is shaped now
+so M2 extends rather than replaces it.
+
+Copyright (c) 2025-2026 Gamma Seeds Pte Ltd. All rights reserved.
+"""
+
+from __future__ import annotations
+
+import enum
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # avoid a hard import cycle / heavy import at module load
+    from terncore.moe.expert_bank import PackedTernaryExpertBank
+
+
+class ConfidenceState(enum.Enum):
+    """Canonical Synapticode confidence states applied to expert residency."""
+
+    SURE = "SURE"
+    UNSURE = "UNSURE"
+    UNKNOWN = "UNKNOWN"
+
+
+class ExpertLifecycle:
+    """Per-(layer, expert) confidence-state view over an expert bank.
+
+    Addressable by ``(layer, expert)`` — the residency unit is the expert
+    (its gate/up/down projections move together), not the individual
+    projection.
+    """
+
+    def __init__(self, bank: "PackedTernaryExpertBank") -> None:
+        self._bank = bank
+
+    def state(self, layer: int, expert: int) -> ConfidenceState:
+        """Confidence state of an expert.
+
+        Milestone 1: SURE if the bank holds the expert (resident), else
+        UNKNOWN (informational — there is no pager to make it SURE yet).
+        """
+        resident = self._bank.has(layer, expert, "gate")
+        return ConfidenceState.SURE if resident else ConfidenceState.UNKNOWN
+
+    def is_resident(self, layer: int, expert: int) -> bool:
+        return self.state(layer, expert) is ConfidenceState.SURE
+
+    def prepare(self, layer: int, expert: int) -> ConfidenceState:
+        """P146 "prepare" phase for an expert about to fire.
+
+        Milestone 1: experts are resident (SURE), so this asserts residency
+        and returns SURE — a no-op. Milestone 2 overrides this to transition
+        UNKNOWN/UNSURE → SURE by paging the expert in from the fast store.
+        """
+        st = self.state(layer, expert)
+        if st is not ConfidenceState.SURE:
+            raise KeyError(
+                f"expert (layer={layer}, expert={expert}) is {st.value}, not "
+                f"resident. Milestone 1 holds every expert SURE; demand-paging "
+                f"of UNSURE/UNKNOWN experts is Milestone 2 (override prepare)."
+            )
+        return st
+
+    def summary(self) -> dict:
+        """Counts by state. Milestone 1: all resident experts are SURE."""
+        n_experts = len(self._bank) // 3 if len(self._bank) else 0
+        return {
+            "resident_experts": n_experts,
+            "states": {"SURE": n_experts, "UNSURE": 0, "UNKNOWN": 0},
+        }

--- a/src/terncore/moe/runnable.py
+++ b/src/terncore/moe/runnable.py
@@ -39,6 +39,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 from terncore.moe.expert_bank import MoEPackedModel, PackedTernaryExpertBank
+from terncore.moe.lifecycle import ExpertLifecycle
 
 _ATTN_PROJ = ("q", "k", "v", "o")
 
@@ -62,10 +63,13 @@ class TernaryMoEBlock(nn.Module):
         top_k: int,
         norm_topk_prob: bool,
         hidden_act: str,
+        lifecycle: "ExpertLifecycle | None" = None,
     ) -> None:
         super().__init__()
         # Tuple wrapper: shared bank reference, deliberately unregistered.
         self._bank_ref = (bank,)
+        # Lifecycle (plain object) is not an nn.Module → not registered.
+        self._lifecycle = lifecycle
         self.layer_idx = int(layer_idx)
         self.num_experts = int(num_experts)
         self.top_k = int(top_k)
@@ -110,7 +114,11 @@ class TernaryMoEBlock(nn.Module):
             e = int(e[0])
             slot, token_idx = torch.where(expert_mask[e])
             cur = x[token_idx]  # [M, H]
-            # P146 "prepare": resident bank lookup (SURE in Milestone 1).
+            # P146 "prepare": ensure the expert is resident. In Milestone 1
+            # this is a SURE no-op; Milestone 2's lifecycle pages it in.
+            if self._lifecycle is not None:
+                self._lifecycle.prepare(self.layer_idx, e)
+            # P146 "launch": resident bank lookup + ternary packed matmul.
             gate = bank.get(self.layer_idx, e, "gate")
             up = bank.get(self.layer_idx, e, "up")
             down = bank.get(self.layer_idx, e, "down")
@@ -161,6 +169,9 @@ def build_runnable_qwen3_moe(
     bank = packed.bank
     protected = packed.protected
     attention = packed.attention
+    # Stage 4: lifecycle beside the bank. M1 holds every expert SURE; its
+    # prepare-phase is a no-op the blocks call before dispatch.
+    lifecycle = ExpertLifecycle(bank)
 
     def prot(name: str) -> torch.Tensor:
         return protected[name].to(dtype)
@@ -184,6 +195,7 @@ def build_runnable_qwen3_moe(
                 top_k=config.num_experts_per_tok,
                 norm_topk_prob=config.norm_topk_prob,
                 hidden_act=config.hidden_act,
+                lifecycle=lifecycle,
             )
         else:  # dense Qwen3MoeMLP layer (none in Qwen3-30B-A3B, but be safe)
             for proj in ("gate", "up", "down"):
@@ -214,6 +226,9 @@ def build_runnable_qwen3_moe(
 
     # Register the shared bank once so model.to(device) moves it.
     model._ternary_expert_bank = bank
+    # Lifecycle is a plain object (not an nn.Module) → attached for queryability
+    # (model._expert_lifecycle.state(layer, expert)) without re-registering bank.
+    model._expert_lifecycle = lifecycle
 
     # Move non-meta state to the target device/dtype. Attention packed
     # modules carry uint8 buffers (dtype-agnostic); protected/router are

--- a/tests/test_moe_lifecycle.py
+++ b/tests/test_moe_lifecycle.py
@@ -1,0 +1,63 @@
+"""
+Tests for the Expert Lifecycle Component (Milestone 1 Stage 4, SURE-only).
+
+Pure unit tests over a hand-built bank — no model assembly, no archive.
+
+Copyright (c) 2025-2026 Gamma Seeds Pte Ltd. All rights reserved.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch.nn as nn
+
+from terncore.moe import (
+    ConfidenceState,
+    ExpertLifecycle,
+    PackedTernaryExpertBank,
+)
+
+
+def _bank_with(layers_experts):
+    bank = PackedTernaryExpertBank()
+    for layer, expert in layers_experts:
+        for proj in ("gate", "up", "down"):
+            bank.add(layer, expert, proj, nn.Linear(2, 2))
+    return bank
+
+
+def test_confidence_state_vocabulary():
+    assert {s.value for s in ConfidenceState} == {"SURE", "UNSURE", "UNKNOWN"}
+
+
+def test_resident_experts_are_sure():
+    lc = ExpertLifecycle(_bank_with([(0, 0), (0, 1), (1, 0)]))
+    assert lc.state(0, 0) is ConfidenceState.SURE
+    assert lc.state(1, 0) is ConfidenceState.SURE
+    assert lc.is_resident(0, 1)
+
+
+def test_absent_expert_is_unknown():
+    lc = ExpertLifecycle(_bank_with([(0, 0)]))
+    assert lc.state(0, 7) is ConfidenceState.UNKNOWN
+    assert not lc.is_resident(0, 7)
+
+
+def test_prepare_is_noop_for_resident():
+    lc = ExpertLifecycle(_bank_with([(0, 0)]))
+    assert lc.prepare(0, 0) is ConfidenceState.SURE
+
+
+def test_prepare_refuses_non_resident_in_m1():
+    """M1 does not page; preparing an absent expert is a loud KeyError
+    (demand-paging of UNSURE/UNKNOWN is Milestone 2)."""
+    lc = ExpertLifecycle(_bank_with([(0, 0)]))
+    with pytest.raises(KeyError, match="Milestone 2"):
+        lc.prepare(0, 9)
+
+
+def test_summary_all_sure_in_m1():
+    lc = ExpertLifecycle(_bank_with([(0, 0), (0, 1), (1, 0), (1, 1)]))
+    s = lc.summary()
+    assert s["resident_experts"] == 4
+    assert s["states"] == {"SURE": 4, "UNSURE": 0, "UNKNOWN": 0}

--- a/tests/test_moe_runnable.py
+++ b/tests/test_moe_runnable.py
@@ -183,6 +183,25 @@ def test_matches_dense_ternary_reference(packed_tiny):
     )
 
 
+def test_runnable_attaches_lifecycle_all_sure(packed_tiny):
+    """build_runnable attaches a SURE-only lifecycle beside the bank; the
+    prepare-phase no-op leaves the forward output unchanged."""
+    from terncore.moe import ConfidenceState
+
+    config, reader = packed_tiny
+    model = build_runnable_qwen3_moe(load_moe_packed(reader, spot_check_n=0), config)
+    lc = model._expert_lifecycle
+    assert lc is not None
+    s = lc.summary()
+    assert s["resident_experts"] == config.num_hidden_layers * config.num_experts
+    assert s["states"]["UNSURE"] == 0 and s["states"]["UNKNOWN"] == 0
+    assert lc.state(0, 0) is ConfidenceState.SURE
+    # Forward still produces finite logits with the prepare no-op in the loop.
+    ids = torch.randint(0, config.vocab_size, (1, 5))
+    with torch.no_grad():
+        assert torch.isfinite(model(ids).logits).all()
+
+
 def test_greedy_generate_runs(packed_tiny):
     config, reader = packed_tiny
     model = build_runnable_qwen3_moe(load_moe_packed(reader, spot_check_n=0), config)


### PR DESCRIPTION
## Summary

Milestone 1 Stage 4 — the Expert Lifecycle Component. **Stacks on #41**
(base is the Stage 2+3 branch); retarget to `main` once #40/#41 land.

`ExpertLifecycle` sits **beside** the `PackedTernaryExpertBank` (not in the
scheduler, not in the model registry — as specified) and is the attach point
for P145's confidence-stratified controlled-operation pattern, mapped onto
expert memory residency:

| state | meaning |
|---|---|
| **SURE** | resident in unified memory — fire immediately |
| **UNSURE** | manifest-known, pageable on selection — *Milestone 2* |
| **UNKNOWN** | cold on disk, not yet touched — *Milestone 2* |

## Tight M1 scope (deliberately)

- `state(layer, expert) -> ConfidenceState` — addressable per expert (the
  residency unit; gate/up/down move together).
- `prepare(layer, expert)` — the P146 "prepare" phase. M1: a **SURE no-op**
  (every expert the bank holds is resident). Refusing a non-resident expert is
  a loud `KeyError` pointing at M2.
- **No** UNSURE/UNKNOWN transitions, **no** demand-pager. Those are Milestone 2,
  where a subclass overrides `prepare` to page in and adds cache/eviction. The
  interface is shaped so M2 extends, not replaces.

`build_runnable_qwen3_moe` attaches a lifecycle beside the bank and wires each
`TernaryMoEBlock` to call `lifecycle.prepare(...)` before dispatch.
`model._expert_lifecycle` exposes `state()` / `summary()`.

## Verification

- 6 lifecycle unit tests (states, residency, prepare no-op, M1 refusal, summary).
- The prepare no-op leaves forward output unchanged — **logit equivalence to the
  dense-ternary reference still passes**.
- Full fast suite: **601 passed, 0 regressions**.

## Milestone 1 status

With this, M1's machinery is complete and verified: load (ternary-resident bank)
→ route (P145 indexing vector) → dispatch (P146 prepare/launch) → lifecycle
(SURE) → generate. A threshold-coherence sweep (0.5/0.55/0.6) is running to find
a coherent artefact (the 0.7 build is below the quality envelope — load verified
faithful vs ground truth).

🤖 Generated with [Claude Code](https://claude.com/claude-code)