### PR TITLE
fix(test): coremltools importorskip in test_qwen3_runtime_ops

### DIFF
--- a/tests/test_pergroup_symmetric_scales.py
+++ b/tests/test_pergroup_symmetric_scales.py
@@ -121,6 +121,7 @@ def test_equivalence_gate_rejects_non_ternary():
 
 # ── 4. CoreML emitter: ternary_g128 → valid MIL @ block_size=128 ──────
 def test_coreml_emitter_block_size_128(tmp_path):
+    pytest.importorskip("coremltools")  # skip where coremltools is absent (CI)
     import coremltools as ct
     from coremltools.converters.mil.mil import Builder as mb, types
     from terncore.coreml_export import _load_weight_for_coreml, _inject_weight

--- a/tests/test_qwen3_runtime_ops.py
+++ b/tests/test_qwen3_runtime_ops.py
@@ -28,6 +28,10 @@ import pytest
 
 torch = pytest.importorskip("torch")
 pytest.importorskip("transformers")
+# terncore.coreml_export (imported below) pulls coremltools at module load;
+# skip the whole module where coremltools is absent (e.g. CI installs
+# .[dev,transformers] only) rather than failing collection.
+pytest.importorskip("coremltools")
 
 from transformers import Qwen3Config  # noqa: E402
 from transformers.models.qwen3.modeling_qwen3 import (  # noqa: E402


### PR DESCRIPTION
Restores green CI by guarding the optional-coremltools import. Identified during PR #44 review — main has been red since d2a5dd4 (Phase 2 Qwen3 runtime ops) due to test_qwen3_runtime_ops doing a top-level coreml_export import that pulls coremltools, which CI doesn't install (`.[dev,transformers]` only).

## Root cause
`tests/test_qwen3_runtime_ops.py` imports `from terncore.coreml_export import (...)` at module top; `coreml_export` imports `coremltools` at load. With coremltools absent in CI, the import raised at **collection**, which pytest treats as a collection error and aborts the entire suite (exit 2) — not just that module.

## Fix
Add `pytest.importorskip("coremltools")` alongside the existing `torch`/`transformers` guards, before the `coreml_export` import. Where coremltools is absent the module is skipped; where present (local/dev) all 8 tests run unchanged.

## Verification
- coremltools **absent** (simulated CI): module skips cleanly, no collection error.
- coremltools **present**: 8/8 tests collect and pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)