### PR TITLE
feat(pack): model-level ternary_g128 pack driver + tool

### DIFF
--- a/src/terncore/pack_g128.py
+++ b/src/terncore/pack_g128.py
@@ -1,0 +1,295 @@
+"""
+Model-level per-group symmetric (``ternary_g128``) pack.
+
+Ingests the genuinely-ternary FP16 weights an MLX-2bit-derived
+``*-unpacked`` repo publishes (e.g. PrismML ``Ternary-Bonsai-*-unpacked``)
+and packs them into tern-core's lossless per-group (128) symmetric
+``ternary_g128`` format — the recommended path for MLX-2bit ternary
+imports.
+
+This is the **lossless** ingest: ternary-eligible weights route through
+:func:`terncore.mlx_ingest.pack_group_symmetric` (per-group scale =
+``max|w|``, ``trit = round(w/scale)``), preserving the per-group scale
+granularity. It is distinct from :func:`terncore.convert.full_convert`,
+whose threshold per-layer-α ``pack_ternary`` path collapses the
+inter-group scale spread and is lossy on per-group-authored weights.
+
+Per-layer hard equivalence gate: :func:`pack_group_symmetric` aborts with
+the offending tensor name + group index on any group whose FP16
+reconstruction drifts beyond two ULP at the group's scale. A single miss
+aborts the whole pack — no lossy approximation is written.
+
+The architecture adapter (e.g. ``qwen3``) decides which weights are
+ternary-eligible (2-D transformer-block projections) versus FP16-retained
+(embeddings, norms, QK-Norm, LM head).
+
+Copyright (c) 2025–2026 Gamma Seeds Pte Ltd. All rights reserved.
+"""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import json
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+import numpy as np
+
+from terncore.mlx_ingest import (
+    GROUP_SIZE_DEFAULT,
+    IngestEquivalenceError,
+    pack_group_symmetric,
+)
+
+
+def _printer(verbose: bool):
+    def _log(msg: str) -> None:
+        if verbose:
+            print(msg, flush=True)
+    return _log
+
+
+def _resolve_model_dir(model_id: str, log) -> Path:
+    p = Path(model_id)
+    if p.is_dir():
+        return p
+    from huggingface_hub import snapshot_download
+
+    log(f"  Resolving {model_id} from HuggingFace Hub …")
+    local = snapshot_download(
+        model_id,
+        allow_patterns=["*.safetensors", "*.safetensors.index.json",
+                        "config.json"],
+    )
+    return Path(local)
+
+
+def _discover_weights(model_dir: Path, log) -> dict:
+    import json as _json
+    from safetensors import safe_open
+
+    weight_to_file: dict = {}
+    index_path = model_dir / "model.safetensors.index.json"
+    single = model_dir / "model.safetensors"
+    if index_path.exists():
+        wmap = _json.loads(index_path.read_text())["weight_map"]
+        for wname, shard in wmap.items():
+            weight_to_file[wname] = model_dir / shard
+        log(f"  Sharded: {len(set(wmap.values()))} shards, "
+            f"{len(weight_to_file)} weights")
+    elif single.exists():
+        with safe_open(str(single), framework="pt", device="cpu") as f:
+            for k in f.keys():
+                weight_to_file[k] = single
+        log(f"  Single shard: {len(weight_to_file)} weights")
+    else:
+        for st in sorted(model_dir.glob("*.safetensors")):
+            with safe_open(str(st), framework="pt", device="cpu") as f:
+                for k in f.keys():
+                    weight_to_file[k] = st
+        log(f"  {len(weight_to_file)} weights across loose shards")
+    if not weight_to_file:
+        raise FileNotFoundError(f"No safetensors files in {model_dir}")
+    return weight_to_file
+
+
+def pack_g128_model(
+    model_id: str,
+    adapter_name: str,
+    output_path: str,
+    *,
+    group_size: int = GROUP_SIZE_DEFAULT,
+    name: str = "model",
+    verbose: bool = True,
+) -> dict:
+    """Pack an unpacked-FP16 ternary model into a ``ternary_g128`` .tern-model.
+
+    Args:
+        model_id:     HuggingFace model ID or local directory of the
+                      ``*-unpacked`` FP16 source.
+        adapter_name: Architecture adapter (e.g. ``"qwen3"``) — decides
+                      ternary-eligible vs FP16-retained weights.
+        output_path:  Path for the ``.tern-model`` output.
+        group_size:   Per-group size along the input axis (default 128).
+        name:         Logical model name recorded in the manifest.
+        verbose:      Print progress.
+
+    Returns:
+        A report dict (layer census, compression, per-layer gate errors).
+
+    Raises:
+        IngestEquivalenceError: any group fails the per-group equivalence
+            gate (the source is not cleanly ternary in that group).
+    """
+    import torch
+    from safetensors import safe_open
+    from terncore.adapters import get_adapter
+    from terncore.tern_model import TernModelWriter
+
+    log = _printer(verbose)
+    t0 = time.perf_counter()
+    adapter = get_adapter(adapter_name)
+
+    log("=" * 68)
+    log(f"  ternary_g128 pack — {adapter.info().name} adapter")
+    log("=" * 68)
+    log(f"  Model:  {model_id}")
+    log(f"  Output: {output_path}")
+
+    model_dir = _resolve_model_dir(model_id, log)
+
+    # Validate adapter routing against the HF config.
+    cfg = json.loads((model_dir / "config.json").read_text())
+    hf_arch = (cfg.get("architectures") or [cfg.get("model_type", "")])[0]
+    adapter.validate_architecture(hf_arch)
+    log(f"  Arch '{hf_arch}' validated against adapter '{adapter.info().name}'")
+
+    weight_to_file = _discover_weights(model_dir, log)
+    file_to_keys: dict = {}
+    for wname, fpath in weight_to_file.items():
+        file_to_keys.setdefault(fpath, []).append(wname)
+
+    # Read shapes + classify.
+    weight_shapes: dict = {}
+    for fpath, keys in file_to_keys.items():
+        with safe_open(str(fpath), framework="pt", device="cpu") as f:
+            for key in keys:
+                parent_shape = list(f.get_slice(key).get_shape())
+                if adapter.expand_stacked(key, parent_shape) is not None:
+                    raise RuntimeError(
+                        f"Stacked/MoE tensor '{key}' is out of scope for the "
+                        f"dense g128 pack; use a dense adapter."
+                    )
+                weight_shapes[key] = parent_shape
+
+    classifications = adapter.classify_all(weight_shapes)
+    eligible = {n for n, c in classifications.items()
+                if c.category == "ternary_eligible"}
+    log(f"  Classified {len(weight_shapes)} weights: "
+        f"{len(eligible)} ternary-eligible, "
+        f"{len(weight_shapes) - len(eligible)} FP16-retain")
+
+    writer = TernModelWriter({
+        "source": model_id,
+        "adapter": adapter_name,
+        "pack": "ternary_g128",
+        "group_size": group_size,
+        "pipeline": "pack_g128_model / per-group lossless ingest",
+    })
+
+    stats = {"g128_layers": 0, "g128_params": 0,
+             "fp16_layers": 0, "fp16_params": 0}
+    per_layer_gate: list = []
+    global_max_err = 0.0
+    total = len(weight_shapes)
+    done = 0
+
+    for fpath, keys in file_to_keys.items():
+        with safe_open(str(fpath), framework="pt", device="cpu") as f:
+            for wname in sorted(keys):
+                canonical = adapter.normalize_name(wname)
+                tensor = f.get_tensor(wname)
+                num_params = tensor.numel()
+
+                if wname in eligible:
+                    w_np = tensor.to(torch.float32).numpy()
+                    pg = pack_group_symmetric(w_np, name=canonical,
+                                              group_size=group_size)
+                    writer.add_ternary_g128_layer(
+                        name=canonical,
+                        packed_weights=pg.packed_weights,
+                        scales=pg.scales,
+                        shape=pg.shape,
+                        scale_shape=pg.scale_shape,
+                        group_size=pg.group_size,
+                        quant_error=pg.max_abs_error,
+                    )
+                    global_max_err = max(global_max_err, pg.max_abs_error)
+                    per_layer_gate.append({
+                        "name": canonical, "shape": pg.shape,
+                        "scale_shape": pg.scale_shape,
+                        "max_abs_error": pg.max_abs_error,
+                    })
+                    stats["g128_layers"] += 1
+                    stats["g128_params"] += num_params
+                    del w_np
+                else:
+                    writer.add_layer(name=canonical,
+                                     weights=tensor.float(), dtype="float16")
+                    stats["fp16_layers"] += 1
+                    stats["fp16_params"] += num_params
+
+                del tensor
+                done += 1
+                if verbose and (done % 50 == 0 or done == total):
+                    log(f"    [{done}/{total}] packed "
+                        f"(g128={stats['g128_layers']}, "
+                        f"fp16={stats['fp16_layers']})")
+        gc.collect()
+
+    log(f"  Equivalence gate GREEN across {stats['g128_layers']} ternary "
+        f"layers (global max_abs_error={global_max_err:.3e})")
+
+    out_file = Path(output_path)
+    out_file.parent.mkdir(parents=True, exist_ok=True)
+    wstats = writer.write(out_file)
+    size = wstats["file_size"]
+    total_params = stats["g128_params"] + stats["fp16_params"]
+    compression = (total_params * 2 / size) if size else 0.0
+    elapsed = time.perf_counter() - t0
+
+    log(f"  Wrote {out_file} — {size/1e6:.1f} MB ({compression:.2f}× vs FP16)")
+
+    return {
+        "status": "PACKED_GATE_GREEN",
+        "model_id": model_id,
+        "adapter": adapter_name,
+        "pack_format": "ternary_g128",
+        "group_size": group_size,
+        "output_path": str(out_file),
+        "file_size_bytes": size,
+        "compression_vs_fp16": round(compression, 2),
+        "total_params": total_params,
+        "global_max_abs_error": global_max_err,
+        **stats,
+        "elapsed_seconds": round(elapsed, 2),
+        "timestamp_utc": datetime.now(timezone.utc).isoformat(),
+        "per_layer_gate": per_layer_gate,
+    }
+
+
+def main(argv: Optional[list] = None) -> int:
+    ap = argparse.ArgumentParser(
+        description="Pack an unpacked-FP16 ternary model into ternary_g128.")
+    ap.add_argument("model", help="HuggingFace model ID or local directory")
+    ap.add_argument("-o", "--output", required=True, help=".tern-model path")
+    ap.add_argument("--adapter", default="qwen3",
+                    help="architecture adapter (default: qwen3)")
+    ap.add_argument("--group-size", type=int, default=GROUP_SIZE_DEFAULT)
+    ap.add_argument("--name", default="model")
+    ap.add_argument("--report", default=None, help="optional JSON report path")
+    ap.add_argument("--quiet", action="store_true")
+    args = ap.parse_args(argv)
+
+    try:
+        report = pack_g128_model(
+            args.model, args.adapter, args.output,
+            group_size=args.group_size, name=args.name,
+            verbose=not args.quiet,
+        )
+    except IngestEquivalenceError as e:
+        print(f"EQUIVALENCE GATE MISS — refusing to pack:\n  {e}",
+              file=sys.stderr, flush=True)
+        return 2
+
+    if args.report:
+        Path(args.report).write_text(json.dumps(report, indent=2) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_pack_g128.py
+++ b/tests/test_pack_g128.py
@@ -1,0 +1,151 @@
+"""
+Integration test for the model-level ternary_g128 pack
+(``terncore.pack_g128.pack_g128_model``).
+
+Synthesises a tiny dense Qwen3 model (config.json + safetensors) whose
+2-D transformer-block projections are genuinely per-group ternary
+(trits × per-128-group scale) and whose embeddings / norms / QK-Norm /
+LM head are FP16. Packs it end-to-end and asserts: the adapter routes
+the expected layer census, the per-group equivalence gate passes
+bit-exact, and the written .tern-model reconstructs to the source
+weights within FP16 tolerance.
+
+Copyright (c) 2025–2026 Gamma Seeds Pte Ltd. All rights reserved.
+"""
+
+from __future__ import annotations
+
+import json
+
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("safetensors")
+
+from safetensors.torch import save_file
+
+from terncore.mlx_ingest import GROUP_SIZE_DEFAULT, IngestEquivalenceError
+from terncore.pack_g128 import pack_g128_model
+from terncore.tern_model import TernModelReader
+
+GS = GROUP_SIZE_DEFAULT
+
+# Tiny dense-Qwen3 geometry; every ternary-eligible input dim is a
+# multiple of the group size (128): hidden = 128 (1 group), intermediate
+# = 256 (2 groups), o_proj in = num_heads*head_dim = 128.
+N_LAYERS = 2
+HIDDEN = 128
+INTER = 256
+N_HEADS = 2
+N_KV = 1
+HEAD_DIM = 64
+VOCAB = 32
+
+
+def _ternary_weight(out_f, in_f, seed):
+    """A genuinely per-group-ternary FP16 weight: trits × per-group scale."""
+    rng = np.random.default_rng(seed)
+    num_groups = in_f // GS
+    trits = rng.integers(-1, 2, size=(out_f, in_f)).astype(np.float32)
+    trits[:, 0::GS] = 1.0  # each group has a +1 so scale == that magnitude
+    scales = (rng.random((out_f, num_groups)) * 0.04 + 0.01).astype(np.float16)
+    w = (trits.reshape(out_f, num_groups, GS)
+         * scales[:, :, None].astype(np.float32)).reshape(out_f, in_f)
+    return torch.from_numpy(w.astype(np.float16))
+
+
+def _fp16(*shape, seed=0):
+    rng = np.random.default_rng(seed)
+    return torch.from_numpy((rng.standard_normal(shape) * 0.02).astype(np.float16))
+
+
+def _build_tiny_qwen3(model_dir):
+    q_out = N_HEADS * HEAD_DIM   # 128
+    kv_out = N_KV * HEAD_DIM     # 64
+    tensors = {
+        "model.embed_tokens.weight": _fp16(VOCAB, HIDDEN, seed=1),
+        "model.norm.weight": _fp16(HIDDEN, seed=2),
+        "lm_head.weight": _fp16(VOCAB, HIDDEN, seed=3),
+    }
+    s = 10
+    for i in range(N_LAYERS):
+        p = f"model.layers.{i}"
+        # ternary-eligible 2-D projections
+        tensors[f"{p}.self_attn.q_proj.weight"] = _ternary_weight(q_out, HIDDEN, s); s += 1
+        tensors[f"{p}.self_attn.k_proj.weight"] = _ternary_weight(kv_out, HIDDEN, s); s += 1
+        tensors[f"{p}.self_attn.v_proj.weight"] = _ternary_weight(kv_out, HIDDEN, s); s += 1
+        tensors[f"{p}.self_attn.o_proj.weight"] = _ternary_weight(HIDDEN, q_out, s); s += 1
+        tensors[f"{p}.mlp.gate_proj.weight"] = _ternary_weight(INTER, HIDDEN, s); s += 1
+        tensors[f"{p}.mlp.up_proj.weight"] = _ternary_weight(INTER, HIDDEN, s); s += 1
+        tensors[f"{p}.mlp.down_proj.weight"] = _ternary_weight(HIDDEN, INTER, s); s += 1
+        # FP16-retained norms (incl. per-head QK-Norm)
+        tensors[f"{p}.input_layernorm.weight"] = _fp16(HIDDEN, seed=s); s += 1
+        tensors[f"{p}.post_attention_layernorm.weight"] = _fp16(HIDDEN, seed=s); s += 1
+        tensors[f"{p}.self_attn.q_norm.weight"] = _fp16(HEAD_DIM, seed=s); s += 1
+        tensors[f"{p}.self_attn.k_norm.weight"] = _fp16(HEAD_DIM, seed=s); s += 1
+
+    save_file(tensors, str(model_dir / "model.safetensors"))
+    config = {
+        "architectures": ["Qwen3ForCausalLM"],
+        "model_type": "qwen3",
+        "hidden_size": HIDDEN,
+        "intermediate_size": INTER,
+        "num_hidden_layers": N_LAYERS,
+        "num_attention_heads": N_HEADS,
+        "num_key_value_heads": N_KV,
+        "head_dim": HEAD_DIM,
+        "vocab_size": VOCAB,
+        "tie_word_embeddings": False,
+    }
+    (model_dir / "config.json").write_text(json.dumps(config))
+    return tensors
+
+
+def test_pack_g128_tiny_qwen3_end_to_end(tmp_path):
+    model_dir = tmp_path / "tiny-qwen3-unpacked"
+    model_dir.mkdir()
+    src = _build_tiny_qwen3(model_dir)
+    out = tmp_path / "tiny.tern-model"
+
+    report = pack_g128_model(
+        str(model_dir), "qwen3", str(out), name="tiny", verbose=False)
+
+    # Census: 7 projections × 2 layers ternary; the rest FP16.
+    assert report["status"] == "PACKED_GATE_GREEN"
+    assert report["g128_layers"] == 7 * N_LAYERS
+    assert report["fp16_layers"] == len(src) - 7 * N_LAYERS
+    # Genuine ternary substrate → gate passes bit-exact.
+    assert report["global_max_abs_error"] == 0.0
+    assert out.exists()
+
+    # Reconstruct a ternary layer and an FP16 layer; both match the source.
+    reader = TernModelReader(out)
+    tern_name = "model.layers.0.mlp.down_proj.weight"
+    recon = reader.reconstruct_layer(tern_name)["weight"].to(torch.float32).numpy()
+    assert np.allclose(recon, src[tern_name].to(torch.float32).numpy(),
+                       atol=1e-3, rtol=0)
+    entry = reader._get_manifest_entry(tern_name)
+    assert entry["dtype"] == "ternary_g128"
+    assert entry["scale_shape"] == [HIDDEN, INTER // GS]
+
+    fp16_name = "model.embed_tokens.weight"
+    assert reader._get_manifest_entry(fp16_name)["dtype"] == "float16"
+
+
+def test_pack_g128_rejects_non_ternary(tmp_path):
+    """A non-ternary eligible weight aborts the pack at the gate."""
+    model_dir = tmp_path / "bad-qwen3-unpacked"
+    model_dir.mkdir()
+    _build_tiny_qwen3(model_dir)
+    # Overwrite one eligible projection with dense Gaussian (non-ternary).
+    from safetensors.torch import load_file
+    tensors = load_file(str(model_dir / "model.safetensors"))
+    rng = np.random.default_rng(99)
+    tensors["model.layers.0.mlp.gate_proj.weight"] = torch.from_numpy(
+        rng.standard_normal((INTER, HIDDEN)).astype(np.float16))
+    save_file(tensors, str(model_dir / "model.safetensors"))
+
+    with pytest.raises(IngestEquivalenceError, match="group"):
+        pack_g128_model(str(model_dir), "qwen3",
+                        str(tmp_path / "bad.tern-model"), verbose=False)

--- a/tools/pack_qwen3_g128.py
+++ b/tools/pack_qwen3_g128.py
@@ -1,0 +1,34 @@
+"""
+Standalone CLI wrapper for the per-group symmetric (ternary_g128) pack.
+
+Packs an unpacked-FP16 ternary model (e.g. PrismML
+``Ternary-Bonsai-*-unpacked``, a dense Qwen3 checkpoint) into tern-core's
+lossless ``ternary_g128`` format, preserving the per-group (128) scale
+granularity.
+
+Usage:
+    python tools/pack_qwen3_g128.py prism-ml/Ternary-Bonsai-8B-unpacked \
+        -o bonsai-8b-g128.tern-model
+    python tools/pack_qwen3_g128.py /path/to/unpacked-dir \
+        -o out.tern-model --adapter qwen3 --report report.json
+
+See also: python -m terncore.pack_g128 (equivalent entry point).
+
+The ``--adapter`` defaults to ``qwen3``; any dense adapter that
+classifies 2-D block projections as ternary-eligible works.
+
+Copyright (c) 2025–2026 Gamma Seeds Pte Ltd. All rights reserved.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Ensure tern-core is importable
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from terncore.pack_g128 import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Promotes the first full-model wiring of `pack_group_symmetric` — proven end-to-end on PrismML Ternary Bonsai 8B during Phase 4 (bit-exact pack, bit-exact logit parity, coherent generation) — into the repo.

## What lands
- **`terncore.pack_g128.pack_g128_model`** — adapter-aware `safetensors → .tern-model` in the lossless per-group symmetric (`ternary_g128`) format. Ternary-eligible 2-D block projections route through `pack_group_symmetric` (per-group scale = `max|w|`, hard equivalence gate, bit-exact); embeddings / norms / per-head QK-Norm / LM head are retained FP16. This is the **lossless** path, distinct from `convert.full_convert`'s threshold per-layer-α `pack_ternary` (lossy on per-group-authored weights).
- **`tools/pack_qwen3_g128.py`** — thin CLI wrapper mirroring `tools/tern_convert.py`; positional model-id, `-o/--output`, `--adapter` (default `qwen3`), `--report`.
- **`tests/test_pack_g128.py`** — integration test on a synthesised tiny dense Qwen3 (2 layers, genuinely per-group-ternary projections): asserts the 7×N_layers ternary / rest-FP16 census, bit-exact gate (`global_max_abs_error == 0`), write→read reconstruction parity, and a loud `IngestEquivalenceError` when an eligible weight is non-ternary.

## CI-safety
`pack_g128` imports only numpy at module load (torch/safetensors/hf_hub are lazy, inside functions); the test guards torch + safetensors with `importorskip`. No coremltools dependency.

## Provenance
Generalised from the Phase-4 staging driver `pack_bonsai8b_g128.py`; the abstraction matches the `tools/` thin-wrapper-over-`src` convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)