### PR TITLE
chore(gitignore): block regenerable artifacts that caused pack bloat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@ build/
 *.tern-model
 *.pt
 *.safetensors
+*.mlpackage
+*.mlpackage/
 models/
 .env
 .venv/
@@ -32,3 +34,15 @@ src/terncore/csrc/test_sparse_skip
 
 # Build-time generated headers
 src/terncore/csrc/terncore_version.h
+
+# Benchmark run outputs — regenerable; large raw dumps belong on the archive
+# (/Volumes/Syn Archive/...), not in VCS. Compact evidence (summary_table.md,
+# *_phase2.json, *_dryrun.json, sensitivity_scan_phi-4_*.json) stays tracked.
+results/
+benchmarks/**/per_expert_tolerance_analysis.json
+benchmarks/**/plot_*.png
+benchmarks/tq_bench_results_*.json
+benchmarks/sensitivity_scan_*_per_channel_*.json
+# Oversized per-model sensitivity dumps (archived); phi-4 (small, dense) stays tracked.
+benchmarks/sensitivity_scan_qwen3*.json
+benchmarks/sensitivity_scan_gemma4*.json


### PR DESCRIPTION
Root-cause fix for the benchmark-artifact bloat surfaced while landing #21/#43. The ignore list blocked only `*.tern-model`/`*.pt`/`*.safetensors` — missing CoreML packages, `results/` run outputs, and the large regenerable dumps.

Adds `*.mlpackage`, `results/`, and targeted benchmark-dump families (per_expert_tolerance_analysis.json, plot_*.png, tq_bench_results_*.json, per-channel + qwen3/gemma4 sensitivity dumps). Compact evidence (summary_table.md, *_phase2.json, *_dryrun.json, phi-4 scan) stays tracked — verified via `git check-ignore`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)