### PR TITLE
feat(adapters): Gemma 4 Unified (encoder-free 12B) adapter + single-file safetensors loader

### DIFF
--- a/src/terncore/adapters/__init__.py
+++ b/src/terncore/adapters/__init__.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 
 _REGISTRY: dict[str, type["ArchitectureAdapter"]] = {}
 
-_KNOWN_ADAPTERS = ["llama", "gemma3", "gemma4", "phi3", "qwen3", "qwen3_moe", "kokoro"]
+_KNOWN_ADAPTERS = ["llama", "gemma3", "gemma4", "gemma4_unified", "phi3", "qwen3", "qwen3_moe", "kokoro"]
 
 
 def register(name: str):

--- a/src/terncore/adapters/gemma4_unified.py
+++ b/src/terncore/adapters/gemma4_unified.py
@@ -1,0 +1,93 @@
+"""
+Gemma 4 Unified (encoder-free) architecture adapter.
+
+Maps Google Gemma 4 *Unified* (``Gemma4UnifiedForConditionalGeneration``,
+``model_type="gemma4_unified"``) HuggingFace weight names to tern-core's
+internal conversion schema. This is the dense 12B "Unified" topology —
+distinct from the encoder-based E4B / MoE variants handled by the base
+:class:`~terncore.adapters.gemma4.Gemma4Adapter`.
+
+Key differences from the encoder-based Gemma 4 (E4B / 26B MoE):
+
+- **Encoder-free multimodal.** No ``vision_tower`` / ``audio_tower``
+  stacks and no ``multi_modal_projector``. Instead a lightweight inline
+  embedder projects raw patches / waveforms directly:
+    * ``model.embed_vision.embedding_projection.weight``
+    * ``model.embed_audio.embedding_projection.weight``
+    * ``model.vision_embedder.{patch_dense,patch_ln*,pos_embedding,pos_norm}``
+  All of these are FP16-retained (modality projection is precision-
+  sensitive and a tiny fraction of the checkpoint; ~35M params).
+- **Dense, not MoE.** The 12B has no expert tensors — ``expert_pattern``
+  is ``None``.
+- **Interleaved attention, value-free globals.** 48 layers = 40
+  ``sliding_attention`` + 8 ``full_attention`` (global) at indices
+  5, 11, 17, 23, 29, 35, 41, 47. The 8 global layers carry q/k/o +
+  q_norm/k_norm but **no discrete ``v_proj``** (``num_kv_shared_layers``
+  is 0 — this is value-free global attention, not KV-sharing). Weight
+  classification is per-tensor, so layers with fewer attention tensors
+  flow through unchanged; the asymmetry matters to the Axis-B KV pass,
+  not to weight conversion.
+
+Text-tower projection names match Llama / the base Gemma 4 adapter
+(q/k/v/o + gate/up/down + the gemma4 norms + ``layer_scalar``), so the
+base classification and stacked-expert (no-op here) logic are inherited.
+
+Copyright (c) 2025-2026 Gamma Seeds Pte Ltd. All rights reserved.
+"""
+
+from __future__ import annotations
+
+from terncore.adapters import register
+from terncore.adapters.base import AdapterInfo
+from terncore.adapters.gemma4 import (
+    _ALWAYS_PROTECTED,
+    _BLOCK_PATTERN,
+    _PROJ_PRIORITY,
+    Gemma4Adapter,
+)
+
+# Dense projection priority — drop the MoE expert entries the base adapter
+# carries (``gemma4_unified`` 12B is dense; keeping them would be inert but
+# misleading). Order preserved by empirical ternary tolerance.
+_DENSE_PROJ_PRIORITY = [
+    p for p in _PROJ_PRIORITY if p not in ("gate_up_proj",)
+]
+
+
+@register("gemma4_unified")
+class Gemma4UnifiedAdapter(Gemma4Adapter):
+    """Architecture adapter for Gemma 4 Unified (encoder-free 12B dense).
+
+    Inherits the base Gemma 4 weight-classification rules and extends the
+    multimodal component patterns to the inline encoder-free embedder so
+    every modality-projection tensor is FP16-retained (never ternarised).
+    """
+
+    # Encoder-free embedder. ``embed_vision`` / ``embed_audio`` already
+    # match the base patterns; ``vision_embedder.*`` (patch_dense,
+    # pos_embedding, ...) is unique to the Unified topology and must be
+    # added or its 2-D ``patch_dense.weight`` would fall through to
+    # ternary-eligible.
+    _VISION_PATTERNS = Gemma4Adapter._VISION_PATTERNS + ["vision_embedder"]
+    _AUDIO_PATTERNS = list(Gemma4Adapter._AUDIO_PATTERNS)
+    _PROJECTOR_PATTERNS = list(Gemma4Adapter._PROJECTOR_PATTERNS)
+
+    def info(self) -> AdapterInfo:
+        return AdapterInfo(
+            name="gemma4_unified",
+            architectures=["Gemma4UnifiedForConditionalGeneration"],
+            model_type="gemma4_unified",
+            description=(
+                "Google Gemma 4 Unified adapter — dense 12B, encoder-free "
+                "multimodal. FP16-retains the inline vision/audio embedder "
+                "(embed_vision / embed_audio / vision_embedder); ternarises "
+                "the language_model decoder tower. No MoE; 8 global layers "
+                "carry no v_proj (value-free global attention)."
+            ),
+            block_pattern=_BLOCK_PATTERN,
+            projection_priority=list(_DENSE_PROJ_PRIORITY),
+            protection_patterns=list(_ALWAYS_PROTECTED),
+            multimodal=True,
+            multimodal_components=["vision", "audio"],
+            expert_pattern=None,  # dense — no experts
+        )

--- a/src/terncore/sharded_loader.py
+++ b/src/terncore/sharded_loader.py
@@ -82,16 +82,28 @@ class ShardedWeightIterator:
     def __init__(self, model_dir: str | Path) -> None:
         self.model_dir = Path(model_dir)
         index_path = self.model_dir / "model.safetensors.index.json"
-        if not index_path.exists():
-            raise FileNotFoundError(
-                f"No safetensors index found at {index_path}. "
-                f"Expected a sharded model with model.safetensors.index.json."
-            )
-        with open(index_path) as f:
-            index = json.load(f)
+        if index_path.exists():
+            with open(index_path) as f:
+                index = json.load(f)
+            self.weight_map: dict[str, str] = index["weight_map"]
+            self.total_size: int = index.get("metadata", {}).get("total_size", 0)
+        else:
+            # Single-file (no-index) checkpoint, e.g. Gemma 4 12B-it ships a
+            # lone model.safetensors. Synthesize a weight_map by reading the
+            # file's header keys so the rest of the iterator is unchanged.
+            single_path = self.model_dir / "model.safetensors"
+            if not single_path.exists():
+                raise FileNotFoundError(
+                    f"No safetensors index at {index_path} and no single-file "
+                    f"{single_path}. Expected either a sharded model with "
+                    f"model.safetensors.index.json or a single model.safetensors."
+                )
+            from safetensors import safe_open
 
-        self.weight_map: dict[str, str] = index["weight_map"]
-        self.total_size: int = index.get("metadata", {}).get("total_size", 0)
+            with safe_open(str(single_path), framework="pt", device="cpu") as f:
+                keys = list(f.keys())
+            self.weight_map = {k: "model.safetensors" for k in keys}
+            self.total_size = single_path.stat().st_size
 
         # Pre-compute block grouping
         self._block_weights: dict[int, list[str]] = defaultdict(list)

--- a/tests/test_adapter_gemma4_unified.py
+++ b/tests/test_adapter_gemma4_unified.py
@@ -1,0 +1,89 @@
+"""
+Tests for the Gemma 4 Unified (encoder-free 12B) architecture adapter.
+
+Covers registration/resolution, the architecture allow-list, and the
+weight-classification contract that matters for a text-only ternary pass:
+the language_model decoder tower is ternary-eligible while every inline
+encoder-free multimodal embedder tensor is FP16-retained.
+
+Copyright (c) 2025-2026 Gamma Seeds Pte Ltd. All rights reserved.
+"""
+
+import pytest
+
+from terncore.adapters import get_adapter
+from terncore.adapters.base import ArchitectureMismatch
+
+
+@pytest.fixture
+def adapter():
+    return get_adapter("gemma4_unified")
+
+
+def test_resolves_and_reports_unified_identity(adapter):
+    info = adapter.info()
+    assert info.name == "gemma4_unified"
+    assert info.model_type == "gemma4_unified"
+    assert info.architectures == ["Gemma4UnifiedForConditionalGeneration"]
+    assert info.multimodal is True
+    # 12B Unified is dense — no MoE expert handling.
+    assert info.expert_pattern is None
+
+
+def test_architecture_allow_list(adapter):
+    # Exact match passes.
+    adapter.validate_architecture("Gemma4UnifiedForConditionalGeneration")
+    # The encoder-based variant must NOT silently route here.
+    with pytest.raises(ArchitectureMismatch):
+        adapter.validate_architecture("Gemma4ForConditionalGeneration")
+
+
+@pytest.mark.parametrize(
+    "name,shape",
+    [
+        ("model.language_model.layers.0.self_attn.q_proj.weight", [4096, 3840]),
+        ("model.language_model.layers.0.self_attn.v_proj.weight", [2048, 3840]),
+        ("model.language_model.layers.0.mlp.gate_proj.weight", [15360, 3840]),
+        ("model.language_model.layers.0.mlp.down_proj.weight", [3840, 15360]),
+        # A global layer (idx 5) still ternarises the projections it DOES have
+        # (q/k/o); it simply lacks v_proj — handled by absence, not by a rule.
+        ("model.language_model.layers.5.self_attn.q_proj.weight", [4096, 3840]),
+    ],
+)
+def test_decoder_tower_is_ternary_eligible(adapter, name, shape):
+    c = adapter.classify_weight(name, shape)
+    assert c.category == "ternary_eligible", c.reason
+    assert c.component == "language"
+
+
+@pytest.mark.parametrize(
+    "name,shape,component",
+    [
+        # Encoder-free inline embedder — all FP16-retained.
+        ("model.embed_vision.embedding_projection.weight", [3840, 1152], "vision"),
+        ("model.embed_audio.embedding_projection.weight", [3840, 640], "audio"),
+        # vision_embedder.* is unique to the Unified topology; its 2-D
+        # patch_dense.weight would fall through to ternary without the
+        # adapter's extended vision pattern — this is the regression guard.
+        ("model.vision_embedder.patch_dense.weight", [1152, 588], "vision"),
+        ("model.vision_embedder.pos_embedding", [1, 256, 1152], "vision"),
+    ],
+)
+def test_multimodal_embedder_is_fp16_retained(adapter, name, shape, component):
+    c = adapter.classify_weight(name, shape)
+    assert c.category == "fp16_retain", c.reason
+    assert c.component == component
+
+
+@pytest.mark.parametrize(
+    "name,shape",
+    [
+        ("model.language_model.layers.0.input_layernorm.weight", [3840]),
+        ("model.language_model.layers.0.layer_scalar", [3840]),
+        ("model.language_model.embed_tokens.weight", [262144, 3840]),
+        ("model.language_model.norm.weight", [3840]),
+    ],
+)
+def test_protected_language_weights_stay_fp16(adapter, name, shape):
+    c = adapter.classify_weight(name, shape)
+    assert c.category == "fp16_retain", c.reason

--- a/tests/test_adapters_registry.py
+++ b/tests/test_adapters_registry.py
@@ -33,7 +33,8 @@ def test_get_adapter_raises_on_unknown_name_case_insensitive():
 
 
 @pytest.mark.parametrize(
-    "name", ["llama", "gemma3", "gemma4", "phi3", "qwen3", "qwen3_moe", "kokoro"]
+    "name",
+    ["llama", "gemma3", "gemma4", "gemma4_unified", "phi3", "qwen3", "qwen3_moe", "kokoro"],
 )
 def test_get_adapter_returns_instance_for_each_known_name(name):
     adapter = get_adapter(name)
@@ -56,5 +57,6 @@ def test_known_adapters_is_canonical_source():
     # ``2026-05-19_kokoro_82m_integration3_attachment_phase0.md``;
     # OQ-1 Option A sibling-cohort placement).
     assert set(_KNOWN_ADAPTERS) == {
-        "llama", "gemma3", "gemma4", "phi3", "qwen3", "qwen3_moe", "kokoro",
+        "llama", "gemma3", "gemma4", "gemma4_unified",
+        "phi3", "qwen3", "qwen3_moe", "kokoro",
     }

--- a/tests/test_sharded_loader_single_file.py
+++ b/tests/test_sharded_loader_single_file.py
@@ -1,0 +1,75 @@
+"""
+Tests for ShardedWeightIterator single-file (no-index) support.
+
+Gemma 4 12B-it ships a single ``model.safetensors`` with no
+``model.safetensors.index.json``. The loader must synthesize a
+weight_map from the file header rather than raising.
+
+Copyright (c) 2025-2026 Gamma Seeds Pte Ltd. All rights reserved.
+"""
+
+import pytest
+import torch
+from safetensors.torch import save_file
+
+from terncore.sharded_loader import (
+    NonBlockWeights,
+    ShardedWeightIterator,
+    WeightBlock,
+)
+
+
+def _write_single_file(model_dir):
+    """Two transformer blocks + non-block weights, one model.safetensors."""
+    tensors = {
+        "model.embed_tokens.weight": torch.randn(32, 8),
+        "model.norm.weight": torch.randn(8),
+        "model.layers.0.self_attn.q_proj.weight": torch.randn(8, 8),
+        "model.layers.0.self_attn.v_proj.weight": torch.randn(8, 8),
+        "model.layers.0.input_layernorm.weight": torch.randn(8),
+        # Layer 1 mimics a value-free global layer: no v_proj.
+        "model.layers.1.self_attn.q_proj.weight": torch.randn(8, 8),
+        "model.layers.1.input_layernorm.weight": torch.randn(8),
+    }
+    save_file(tensors, str(model_dir / "model.safetensors"))
+    return tensors
+
+
+def test_single_file_synthesizes_weight_map(tmp_path):
+    written = _write_single_file(tmp_path)
+    loader = ShardedWeightIterator(tmp_path)
+
+    assert loader.num_weights == len(written)
+    # Every tensor maps to the lone file.
+    assert set(loader.weight_map.values()) == {"model.safetensors"}
+    assert loader.total_size == (tmp_path / "model.safetensors").stat().st_size
+    assert loader.block_indices == [0, 1]
+    assert loader.num_blocks == 2
+
+
+def test_single_file_iter_blocks_loads_tensors(tmp_path):
+    written = _write_single_file(tmp_path)
+    loader = ShardedWeightIterator(tmp_path)
+
+    blocks = {}
+    non_block = None
+    for item in loader:
+        if isinstance(item, WeightBlock):
+            blocks[item.block_idx] = item
+        elif isinstance(item, NonBlockWeights):
+            non_block = item
+
+    assert set(blocks) == {0, 1}
+    # Value-free global layer (block 1) loads with no v_proj, no crash.
+    assert "model.layers.1.self_attn.q_proj.weight" in blocks[1].weights
+    assert "model.layers.1.self_attn.v_proj.weight" not in blocks[1].weights
+    # Byte-faithful round-trip on a sampled tensor.
+    got = blocks[0].weights["model.layers.0.self_attn.q_proj.weight"]
+    assert torch.equal(got, written["model.layers.0.self_attn.q_proj.weight"])
+    assert non_block is not None
+    assert "model.embed_tokens.weight" in non_block.weights
+
+
+def test_missing_both_index_and_single_file_raises(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        ShardedWeightIterator(tmp_path)

--- a/tools/tern_ppl_bench.py
+++ b/tools/tern_ppl_bench.py
@@ -526,10 +526,24 @@ def evaluate_ppl_autoregressive(
 # ── Model loading (R7-A §7) ────────────────────────────────────────────
 
 
-def load_fp16_baseline(model_id: str, device: str) -> tuple[Any, Any]:
+def load_fp16_baseline(
+    model_id: str,
+    device: str,
+    tokenizer_source: Optional[str] = None,
+    dtype: "torch.dtype" = torch.float16,
+) -> tuple[Any, Any]:
     """
-    Load FP16 baseline per R7-A §7: ``AutoModelForCausalLM.from_pretrained
-    (model_id, torch_dtype=torch.float16)`` + matching tokenizer.
+    Load FP baseline per R7-A §7: ``AutoModelForCausalLM.from_pretrained
+    (model_id, torch_dtype=dtype)`` + matching tokenizer.
+
+    ``tokenizer_source`` overrides where the tokenizer is loaded from
+    (defaults to ``model_id``). Used when a checkpoint's own tokenizer
+    files are absent from cache but a family-identical tokenizer is
+    available locally (e.g. the shared Gemma 4 tokenizer, vocab 262144).
+
+    ``dtype`` is the compute dtype (default float16 to preserve the
+    Llama-era baseline). Gemma checkpoints need bfloat16 — float16
+    overflows their soft-capping and yields a meaningless PPL.
     """
     try:
         from transformers import AutoModelForCausalLM, AutoTokenizer
@@ -538,10 +552,17 @@ def load_fp16_baseline(model_id: str, device: str) -> tuple[Any, Any]:
             "transformers required: pip install terncore[transformers]"
         ) from e
 
-    tokenizer = AutoTokenizer.from_pretrained(model_id)
+    tokenizer = AutoTokenizer.from_pretrained(tokenizer_source or model_id)
+    # Gemma 4 multimodal checkpoints (E4B encoder-based; 12B Unified) store
+    # the decoder under a ``model.language_model.*`` namespace. AutoModel-
+    # ForCausalLM resolves to the matching *ConditionalGeneration class,
+    # which maps those prefixed keys; forward(input_ids) routes the text
+    # path so WikiText-2 PPL is text-only-correct. (Forcing the text-only
+    # Gemma4ForCausalLM mis-maps the prefix → random weights → PPL blowout;
+    # caught by the R7 envelope check.)
     model = AutoModelForCausalLM.from_pretrained(
         model_id,
-        torch_dtype=torch.float16,
+        torch_dtype=dtype,
         low_cpu_mem_usage=True,
     )
     model = model.to(device)
@@ -972,6 +993,17 @@ def main() -> None:
         help="Override tokenizer source (default: resolves from model id)",
     )
     parser.add_argument("--device", type=str, default="mps")
+    parser.add_argument(
+        "--dtype",
+        type=str,
+        default="float16",
+        choices=["float16", "bfloat16", "float32"],
+        help=(
+            "FP baseline compute dtype (default float16). Gemma models "
+            "(soft-capping + sqrt-hidden embedding scale) are numerically "
+            "unstable in float16 — use bfloat16 for an honest Gemma baseline."
+        ),
+    )
     parser.add_argument("--seq-len", type=int, default=DEFAULT_SEQ_LEN)
     parser.add_argument("--stride", type=int, default=DEFAULT_STRIDE)
     parser.add_argument(
@@ -1100,11 +1132,17 @@ def main() -> None:
         source_path = str(args.tern_model_path)
         dtype_activation = "mixed"
     else:
-        model, tokenizer = load_fp16_baseline(args.model_id, args.device)
+        baseline_dtype = getattr(torch, args.dtype)
+        model, tokenizer = load_fp16_baseline(
+            args.model_id,
+            args.device,
+            tokenizer_source=args.tokenizer,
+            dtype=baseline_dtype,
+        )
         manifest_sha = None
         model_id = args.model_id
         source_path = args.model_id
-        dtype_activation = "float16"
+        dtype_activation = args.dtype
 
     tokenizer_source = args.tokenizer or model_id
     model_load_seconds = time.perf_counter() - t_load


### PR DESCRIPTION
## Summary
Adds tern-core support for **Gemma 4 Unified** (the encoder-free dense 12B, `Gemma4UnifiedForConditionalGeneration` / `model_type=gemma4_unified`) and the single-file safetensors layout it ships in.

- **`adapters/gemma4_unified.py`** — `Gemma4UnifiedAdapter` (subclass of `Gemma4Adapter`): registers the unified arch/model_type; **FP16-retains the inline encoder-free embedder** (`embed_vision` / `embed_audio` / `vision_embedder.*`); dense (no MoE); the 8 value-free **global** layers (no `v_proj`, indices 5/11/17/23/29/35/41/47) are handled per-tensor.
- **`sharded_loader.py`** — single-file **no-index** fallback: synthesize `weight_map` from the file header. Gemma 4 12B-it ships one 24 GB `model.safetensors` with no `index.json`.
- **`tools/tern_ppl_bench.py`** — `--dtype` flag (use **bf16** for Gemma numerics) + tokenizer-source override (the Gemma 4 family shares one tokenizer, vocab 262144).
- **Tests** — adapter classification + single-file loader (18 new); registry canonical-source test updated for the new adapter.

## Validation
- **Full suite: 720 passed, 8 skipped, 1 xfailed** (0 failures).
- Dry-run + real ternary **compress validated on the actual 22 GB `google/gemma-4-12B-it` checkpoint**: **3.8× vs BF16 @ threshold 0.7** (318 ternary + 10 INT4 + 349 FP16). Held **structural / weight-only / coherence-pending**.

## Scope note
The **compression path here is independent and green**. The 12B-it **text-only _inference_** (needed for the same-harness PPL eval) is **blocked upstream** by a transformers `5.10.0.dev0` `Gemma4Unified` forward bug (text-only collapses; llama.cpp runs the same weights coherently). Diagnosis + queue recorded in `synapticode-ops` **DISPOSITION_QUEUE Q15**; quality eval re-runs from staged assets once the upstream forward is fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)