### PR TITLE
feat(tools): canonical Gemma 4 Unified .tern-model PPL loader

### DIFF
--- a/tests/test_gemma4_unified_ppl_loader.py
+++ b/tests/test_gemma4_unified_ppl_loader.py
@@ -1,0 +1,139 @@
+"""Unit tests for the Gemma 4 Unified PPL loader (tools/gemma4_unified_ppl.py).
+
+Covers the two pieces the stock ``tern_ppl_bench`` loader lacks and which this
+tool exists to provide:
+
+1. ``translate_name`` — bridges the manifest's logical Gemma names
+   (``model.layers.*`` …) to the transformers-5.10 ``model.language_model.*``
+   tree, passing the multimodal embedder names through unchanged.
+2. ``overlay`` strict-quant gate — places decoder-tower entries, tolerates
+   text-irrelevant multimodal FP16 entries that are absent from a text
+   ``CausalLM``, and flags any *ternary/INT4* entry that fails to place
+   (a silent decoder-tower miss would corrupt the measurement).
+
+These exercise the load-bearing logic with lightweight fakes — no model
+download, no transformers forward.
+
+Copyright (c) 2025-2026 Gamma Seeds Pte Ltd. All rights reserved.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import torch
+
+# ── Import the loader module via path (lives in tools/, not src/) ──────
+_TOOL_PATH = Path(__file__).resolve().parent.parent / "tools" / "gemma4_unified_ppl.py"
+_spec = importlib.util.spec_from_file_location("gemma4_unified_ppl", _TOOL_PATH)
+assert _spec is not None and _spec.loader is not None
+gemma4_unified_ppl = importlib.util.module_from_spec(_spec)
+sys.modules["gemma4_unified_ppl"] = gemma4_unified_ppl
+_spec.loader.exec_module(gemma4_unified_ppl)
+
+translate_name = gemma4_unified_ppl.translate_name
+overlay = gemma4_unified_ppl.overlay
+
+
+# ── translate_name: text-tower bridge + multimodal passthrough ─────────
+
+def test_translate_text_tower_prefixes():
+    cases = {
+        "model.layers.0.self_attn.q_proj.weight":
+            "model.language_model.layers.0.self_attn.q_proj.weight",
+        "model.layers.47.mlp.down_proj.weight":
+            "model.language_model.layers.47.mlp.down_proj.weight",
+        "model.embed_tokens.weight":
+            "model.language_model.embed_tokens.weight",
+        "model.norm.weight":
+            "model.language_model.norm.weight",
+    }
+    for raw, expected in cases.items():
+        assert translate_name(raw) == expected
+
+
+def test_translate_multimodal_and_unknown_passthrough():
+    # Vision/audio embedder names and already-nested names are untouched.
+    passthrough = [
+        "model.embed_vision.embedding_projection.weight",
+        "model.embed_audio.embedding_projection.weight",
+        "model.vision_embedder.patch_dense.weight",
+        "lm_head.weight",
+        "model.language_model.layers.0.self_attn.q_proj.weight",
+    ]
+    for name in passthrough:
+        assert translate_name(name) == name
+
+
+# ── overlay: placement + strict-quant gate ─────────────────────────────
+
+def _fake_model(keyed_params):
+    """A minimal model exposing named_parameters()/named_buffers()."""
+    items = [(k, torch.nn.Parameter(torch.ones(*shape), requires_grad=False))
+             for k, shape in keyed_params.items()]
+    return SimpleNamespace(
+        named_parameters=lambda: list(items),
+        named_buffers=lambda: [],
+    )
+
+
+def _fake_reader(entries):
+    """A reader stub: manifest entries + reconstruct_layer by name."""
+    by_name = {e["name"]: e for e in entries}
+
+    def reconstruct_layer(name):
+        return {"weight": torch.zeros(*by_name[name]["shape"])}
+
+    return SimpleNamespace(
+        manifest={"layers": entries},
+        reconstruct_layer=reconstruct_layer,
+    )
+
+
+def test_overlay_places_decoder_skips_multimodal():
+    # Decoder ternary entry resolves via the text-tower map; an absent
+    # multimodal FP16 entry is skipped but NOT a quant miss.
+    model = _fake_model({
+        "model.language_model.layers.0.self_attn.q_proj.weight": (4, 4),
+    })
+    reader = _fake_reader([
+        {"name": "model.layers.0.self_attn.q_proj.weight",
+         "dtype": "ternary2", "shape": (4, 4)},
+        {"name": "model.embed_vision.embedding_projection.weight",
+         "dtype": "float16", "shape": (2, 2)},
+    ])
+    rep = overlay(reader, model)
+    assert rep["placed"] == 1
+    assert rep["fail"] == []
+    assert rep["skipped_quant"] == []          # gate clean
+    assert len(rep["skipped"]) == 1            # the multimodal FP16 entry
+
+
+def test_overlay_gate_flags_missing_quant_entry():
+    # A ternary entry whose (translated) key is absent must surface as a
+    # quant miss so the caller aborts rather than measure a corrupt model.
+    model = _fake_model({
+        "model.language_model.layers.0.self_attn.q_proj.weight": (4, 4),
+    })
+    reader = _fake_reader([
+        {"name": "model.layers.99.self_attn.k_proj.weight",   # no such layer
+         "dtype": "ternary2", "shape": (4, 4)},
+    ])
+    rep = overlay(reader, model)
+    assert rep["placed"] == 0
+    assert len(rep["skipped_quant"]) == 1
+
+
+def test_overlay_flags_shape_mismatch():
+    model = _fake_model({
+        "model.language_model.layers.0.self_attn.q_proj.weight": (4, 4),
+    })
+    reader = _fake_reader([
+        {"name": "model.layers.0.self_attn.q_proj.weight",
+         "dtype": "ternary2", "shape": (8, 8)},   # wrong shape
+    ])
+    rep = overlay(reader, model)
+    assert len(rep["fail"]) == 1
+    assert rep["placed"] == 0

--- a/tools/gemma4_unified_ppl.py
+++ b/tools/gemma4_unified_ppl.py
@@ -1,0 +1,241 @@
+"""Canonical WikiText-2 PPL loader for Gemma 4 *Unified* (.tern-model) artefacts.
+
+``tools/tern_ppl_bench.py --tern-model-path`` loads a ternary variant through
+``TernModelReader.load_packed_model``, whose module-tree walker raises on the
+Gemma 4 Unified (``gemma4_unified``, ``Gemma4UnifiedForConditionalGeneration``)
+manifest:
+
+* The manifest stores text-tower tensors under **logical** Gemma names
+  (``model.layers.*`` / ``model.embed_tokens.*`` / ``model.norm.*``), while
+  transformers 5.10 nests the decoder under ``model.language_model.*``.
+* The FP16-retained inline multimodal projectors
+  (``model.embed_vision.*`` / ``model.embed_audio.*`` / ``model.vision_embedder.*``)
+  have no matching submodule when the checkpoint is instantiated as a text
+  ``AutoModelForCausalLM`` — they are irrelevant to a text-only WikiText-2 forward.
+
+This module supplies the canonical text-only PPL path for Unified artefacts:
+
+1. Materialise the FP32 skeleton via ``AutoModelForCausalLM``.
+2. Overlay the reconstructed weights by **flat state-dict key**, streaming one
+   layer at a time (bounded memory — no full second state-dict), translating
+   logical names → the transformers-5.10 tree via the canonical
+   ``GEMMA4_MULTIMODAL_TRANSFORMERS_5_5`` preset.
+3. Skip manifest keys absent from the text model, while **hard-failing if any
+   ternary / INT4 entry fails to place** (a missing decoder-tower entry would
+   silently corrupt the measurement).
+4. Compute PPL with the harness's canonical R7-A ``evaluate_ppl`` so the number
+   is methodology-identical to the FP baseline produced by ``tern_ppl_bench``.
+
+The text-tower name bridge and the strict-quant overlay gate are the two pieces
+the stock loader lacks; everything downstream reuses ``tern_ppl_bench``.
+
+Usage::
+
+    python tools/gemma4_unified_ppl.py \
+        --tern-model-path model.tern-model \
+        --source-model-id google/gemma-4-12B \
+        --device mps --seq-len 2048 --stride 2048 \
+        --baseline-ppl 8.4638
+
+Patents 10-12: automated binary-to-ternary conversion + faithful reconstruction.
+
+Copyright (c) 2025-2026 Gamma Seeds Pte Ltd. All rights reserved.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+
+import torch
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "src"))
+sys.path.insert(0, str(ROOT / "tools"))
+
+import terncore  # noqa: E402
+from terncore.tern_model import (  # noqa: E402
+    TernModelReader,
+    GEMMA4_MULTIMODAL_TRANSFORMERS_5_5 as TEXT_TOWER_MAP,
+)
+import tern_ppl_bench as B  # noqa: E402
+
+# Manifest dtypes that MUST place — a decoder-tower entry that fails to overlay
+# would silently corrupt the measurement, so the overlay gate aborts on these.
+QUANT_DTYPES = {"ternary2", "ternary_g128", "int4_block32"}
+
+
+def translate_name(name: str) -> str:
+    """Bridge logical manifest names → the transformers 5.10 module tree.
+
+    The Unified manifest stores text-tower tensors under logical Gemma names
+    (``model.layers.*`` / ``model.embed_tokens.*`` / ``model.norm.*``);
+    transformers 5.10 nests them under ``model.language_model.*``. First prefix
+    match wins; unmatched names (the vision/audio embedder) pass through
+    unchanged.
+    """
+    for src, dst in TEXT_TOWER_MAP.items():
+        if name.startswith(src):
+            return dst + name[len(src):]
+    return name
+
+
+def overlay(reader: TernModelReader, model: torch.nn.Module) -> dict:
+    """Stream-overlay reconstructed weights onto ``model`` by flat key.
+
+    Returns a report dict with placement counts. Caller must treat a non-empty
+    ``skipped_quant`` (any ternary/INT4 entry that failed to place) or ``fail``
+    (shape mismatch) as fatal.
+    """
+    params = dict(model.named_parameters())
+    params.update(dict(model.named_buffers()))
+    keyset = set(params.keys())
+
+    placed: list[str] = []
+    skipped: list[tuple[str, str]] = []
+    fail: list[tuple] = []
+    counts: dict[str, int] = {}
+
+    for entry in reader.manifest["layers"]:
+        raw_name = entry["name"]            # manifest key — reconstruct with this
+        mapped = translate_name(raw_name)   # model-tree key — match/copy with this
+        dtype = entry.get("dtype", "float16")
+        counts[dtype] = counts.get(dtype, 0) + 1
+        tensors = reader.reconstruct_layer(raw_name)
+        for sub, tensor in tensors.items():
+            if mapped in keyset:
+                key = mapped
+            elif f"{mapped}.{sub}" in keyset:
+                key = f"{mapped}.{sub}"
+            elif sub == "bias" and mapped.endswith(".weight") and \
+                    mapped[:-7] + ".bias" in keyset:
+                key = mapped[:-7] + ".bias"
+            else:
+                key = mapped if sub == "weight" else f"{mapped}.{sub}"
+
+            if key in keyset:
+                p = params[key]
+                if tuple(p.shape) != tuple(tensor.shape):
+                    fail.append((key, tuple(p.shape), tuple(tensor.shape)))
+                    continue
+                with torch.no_grad():
+                    p.copy_(tensor.to(p.dtype))
+                placed.append(key)
+            else:
+                skipped.append((key, dtype))
+        del tensors
+
+    skipped_quant = [(k, d) for (k, d) in skipped if d in QUANT_DTYPES]
+    return {
+        "placed": len(placed), "skipped": skipped, "fail": fail,
+        "skipped_quant": skipped_quant, "counts": counts,
+    }
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(
+        description="WikiText-2 PPL for Gemma 4 Unified .tern-model artefacts"
+    )
+    ap.add_argument("--tern-model-path", required=True)
+    ap.add_argument("--source-model-id", default="google/gemma-4-12B")
+    ap.add_argument("--device", default="mps")
+    ap.add_argument("--seq-len", type=int, default=2048)
+    ap.add_argument("--stride", type=int, default=2048)
+    ap.add_argument("--baseline-ppl", type=float, default=None)
+    ap.add_argument("--output-dir", default=str(ROOT / "results" / "wikitext2_ppl"))
+    ap.add_argument("--notes", default="")
+    args = ap.parse_args()
+
+    from transformers import AutoModelForCausalLM, AutoTokenizer
+
+    print(f"[gemma4-ppl] loading fp32 skeleton {args.source_model_id} ...", flush=True)
+    t0 = time.perf_counter()
+    tok = AutoTokenizer.from_pretrained(args.source_model_id)
+    model = AutoModelForCausalLM.from_pretrained(
+        args.source_model_id, torch_dtype=torch.float32, low_cpu_mem_usage=True
+    )
+    print(f"[gemma4-ppl]   skeleton loaded in {time.perf_counter()-t0:.1f}s", flush=True)
+
+    reader = TernModelReader(Path(args.tern_model_path))
+    print("[gemma4-ppl] overlaying reconstructed weights (streaming) ...", flush=True)
+    t1 = time.perf_counter()
+    rep = overlay(reader, model)
+    print(f"[gemma4-ppl]   overlay done in {time.perf_counter()-t1:.1f}s", flush=True)
+    print(f"[gemma4-ppl]   manifest dtype counts: {rep['counts']}", flush=True)
+    print(f"[gemma4-ppl]   placed={rep['placed']} skipped={len(rep['skipped'])} "
+          f"fail={len(rep['fail'])}", flush=True)
+    if rep["skipped"]:
+        print(f"[gemma4-ppl]   skipped (text-irrelevant) first 8: "
+              f"{rep['skipped'][:8]}", flush=True)
+    if rep["fail"]:
+        print(f"[gemma4-ppl]   FAIL (shape mismatch): {rep['fail'][:8]}", flush=True)
+        sys.exit(2)
+    if rep["skipped_quant"]:
+        print(f"[gemma4-ppl]   ABORT — ternary/INT4 entries did not place: "
+              f"{rep['skipped_quant'][:8]}", flush=True)
+        sys.exit(3)
+
+    model = model.to(args.device)
+    model.eval()
+
+    print("[gemma4-ppl] loading WikiText-2 test split ...", flush=True)
+    test_text, hf_rev = B.load_wikitext2_test_text()
+    bos = tok.bos_token_id
+    tokens = B.prepare_tokens(test_text, tok, bos)
+    print(f"[gemma4-ppl]   tokens: {tokens.shape[0]:,} "
+          f"(bos_prepended={bos is not None})", flush=True)
+
+    print(f"[gemma4-ppl] eval seq_len={args.seq_len} stride={args.stride} ...", flush=True)
+    t2 = time.perf_counter()
+    res = B.evaluate_ppl(model, tokens, args.seq_len, args.stride, args.device)
+    print(f"[gemma4-ppl]   PPL = {res.ppl:.4f} (windows={res.windows_evaluated}, "
+          f"scored={res.tokens_scored:,}, {time.perf_counter()-t2:.1f}s)", flush=True)
+
+    headroom = None
+    if args.baseline_ppl:
+        headroom = (res.ppl - args.baseline_ppl) / args.baseline_ppl
+        print(f"[gemma4-ppl]   baseline={args.baseline_ppl} "
+              f"ppl_headroom={headroom:.4f} "
+              f"band={B.classify_ppl_headroom_band(headroom)}", flush=True)
+
+    out = {
+        "schema_version": "wikitext2_ppl/1.0-unified-overlay",
+        "run_id": B.utc_now_compact(),
+        "timestamp_utc": B.utc_now_iso(),
+        "tern_core_version": terncore.__version__,
+        "tern_core_git_commit": B.git_commit_short(),
+        "model": {"model_id": args.source_model_id, "variant": "ternary",
+                  "source_path": args.tern_model_path,
+                  "load_path": "streaming_overlay_strict_quant"},
+        "manifest_dtype_counts": rep["counts"],
+        "overlay": {"placed": rep["placed"], "skipped": len(rep["skipped"])},
+        "tokeniser": {"bos_token_id": bos, "bos_prepended": bos is not None},
+        "dataset": {"name": B.WIKITEXT_CONFIG, "split": B.WIKITEXT_SPLIT,
+                    "huggingface_revision": hf_rev,
+                    "total_tokens": int(tokens.shape[0]),
+                    "tokens_discarded": res.tokens_discarded},
+        "methodology": {"spec_version": B.SPEC_VERSION, "seq_len": args.seq_len,
+                        "stride": args.stride},
+        "hardware": {"device": args.device, "dtype_activation": "float32",
+                     "dtype_loss": "float32"},
+        "results": {"windows_evaluated": res.windows_evaluated,
+                    "tokens_scored": res.tokens_scored,
+                    "mean_loss": round(res.mean_loss, 6), "ppl": round(res.ppl, 4)},
+        "comparison": {"baseline_ppl": args.baseline_ppl,
+                       "ppl_headroom": round(headroom, 4) if headroom is not None else None,
+                       "ppl_headroom_band": (B.classify_ppl_headroom_band(headroom)
+                                             if headroom is not None else None)},
+        "notes": args.notes,
+    }
+    outdir = Path(args.output_dir)
+    outdir.mkdir(parents=True, exist_ok=True)
+    outpath = outdir / f"ppl_gemma4_unified_overlay_{out['run_id']}.json"
+    outpath.write_text(json.dumps(out, indent=2), encoding="utf-8")
+    print(f"[gemma4-ppl]   wrote {outpath}", flush=True)
+    print(f"[gemma4-ppl]   ppl = {out['results']['ppl']}", flush=True)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Adds `tools/gemma4_unified_ppl.py` — the canonical text-only WikiText-2 PPL path for **Gemma 4 Unified** (`gemma4_unified` / `Gemma4UnifiedForConditionalGeneration`) `.tern-model` artefacts.

## Why

`tern_ppl_bench --tern-model-path` drives `TernModelReader.load_packed_model`, whose module-tree walker **raises** on the Unified manifest:

- text-tower tensors are stored under **logical** Gemma names (`model.layers.*`, `model.embed_tokens.*`, `model.norm.*`) while transformers 5.10 nests the decoder under `model.language_model.*`;
- the FP16-retained inline multimodal projectors (`embed_vision` / `embed_audio` / `vision_embedder`) have **no submodule** when the checkpoint is loaded as a text `AutoModelForCausalLM`, and are irrelevant to a text-only forward.

## How

A tolerant streaming overlay:
1. bridges logical → transformers-5.10 names via the existing `GEMMA4_MULTIMODAL_TRANSFORMERS_5_5` preset;
2. places reconstructed weights by **flat state-dict key**, one layer at a time (bounded memory — no full second state-dict);
3. **skips** text-irrelevant multimodal keys absent from the text model, while **hard-failing** if any *ternary/INT4* entry fails to place (a silent decoder-tower miss would corrupt the measurement);
4. computes PPL with the harness's canonical R7-A `evaluate_ppl` — methodology-identical to the FP baseline.

## Validation

google/gemma-4-12B **base** (Q15 quality leg): BF16 PPL **8.4638** → t0.7 ternary **1.44e9** (overlay `placed=667 / fail=0`, only the 10 vision projectors skipped). Evidence on `ecc-ternary` `results` branch (`compression-quality/GEMMA4_12B_BASE_QUALITY_20260610T235557Z`).

## Tests

`tests/test_gemma4_unified_ppl_loader.py` — name-bridge + strict-quant gate (placement, multimodal skip, missing-quant abort, shape mismatch) with lightweight fakes, no model download. **5/5 pass** locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)